### PR TITLE
Add Stage 0 sample dataset and documentation

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,38 @@
+# Stage 0 Sample Dataset
+
+This directory contains a compact CSV snapshot that mirrors the canonical Stage 0 ingestion schema for Rosaviatsiya drone flight reports. The file `rosaviation_sample.csv` provides representative rows that satisfy the baseline aggregation rules captured in `docs/requirements.md` and `plan.md`.
+
+## File overview
+
+| File | Description |
+| --- | --- |
+| `rosaviation_sample.csv` | Synthetic dataset covering multiple Russian regions and months for 2024, structured according to the Stage 0 metrics contract. |
+
+## Schema and units
+
+| Column | Type | Units / Format | Notes |
+| --- | --- | --- | --- |
+| `flight_id` | string | UUID-like string | Unique identifier used for deduplication (`flight_id`, `start_time`, `region_code`). |
+| `start_time` | datetime | ISO 8601 UTC | Normalized timestamp of take-off in UTC to support time-based aggregation. |
+| `end_time` | datetime | ISO 8601 UTC | Landing timestamp in UTC; combined with `start_time` to derive durations. |
+| `duration_minutes` | integer | minutes | Pre-computed duration to simplify QA; Stage 0 logic can recompute to validate. |
+| `region_code` | string | Rosstat/ISO-style code | Key for joining to region directory tables (e.g., `RU-MOW`). |
+| `region_name` | string | UTF-8 text | Human-readable region label for quick inspection. |
+| `latitude` | decimal | degrees | Take-off latitude; supports geo-quality checks and Stage 0 geofencing rules. |
+| `longitude` | decimal | degrees | Take-off longitude; supports geo-quality checks and Stage 0 geofencing rules. |
+| `vehicle_category` | string | enum | Differentiates quadrotor/fixed-wing/hybrid for optional breakdowns. |
+| `operator_type` | string | enum | Enables Stage 0 grouping (commercial/government/research/etc.). |
+| `flight_purpose` | string | enum | Provides downstream insight context without affecting Stage 0 totals. |
+| `payload_type` | string | enum | Recorded payload classification; used for optional filters.
+
+## How this sample supports Stage 0 metrics
+
+The dataset spans multiple regions and months, enabling validation of the baseline aggregation rules:
+
+1. **Flight count and deduplication:** Distinct `flight_id` values allow verification of unique flight counting across regions.
+2. **Duration metrics:** `start_time`, `end_time`, and `duration_minutes` cover computation of total/average durations while enforcing the >0 minute rule.
+3. **Monthly trends:** Records across January–March 2024 ensure month-over-month calculations are testable.
+4. **Regional rankings:** Multiple `region_code` values support Top-N region summaries.
+5. **Optional segmentations:** `vehicle_category` and `operator_type` provide the categorical dimensions referenced in Stage 0 planning documents.
+
+Ingest agents can load this file directly to exercise validation, quality, and aggregation workflows before scaling to full production batches.

--- a/samples/rosaviation_sample.csv
+++ b/samples/rosaviation_sample.csv
@@ -1,0 +1,6 @@
+flight_id,start_time,end_time,duration_minutes,region_code,region_name,latitude,longitude,vehicle_category,operator_type,flight_purpose,payload_type
+RU-2024-0001,2024-01-15T06:45:00Z,2024-01-15T07:30:00Z,45,RU-MOW,Москва,55.7558,37.6173,quadrotor,commercial,airspace survey,imaging
+RU-2024-0002,2024-01-22T09:10:00Z,2024-01-22T09:42:00Z,32,RU-SPE,Санкт-Петербург,59.9311,30.3609,quadrotor,government,infrastructure inspection,thermal
+RU-2024-0105,2024-02-05T04:00:00Z,2024-02-05T05:05:00Z,65,RU-MOW,Москва,55.7512,37.6184,fixed-wing,research,meteorological survey,atmospheric sensors
+RU-2024-0110,2024-02-18T11:30:00Z,2024-02-18T12:00:00Z,30,RU-SVE,Свердловская область,56.8389,60.6057,quadrotor,commercial,logistics,basic cargo
+RU-2024-0201,2024-03-03T08:25:00Z,2024-03-03T09:15:00Z,50,RU-KDA,Краснодарский край,45.0355,38.9753,hybrid VTOL,emergency,response support,medical supplies


### PR DESCRIPTION
## Summary
- add a Stage 0 Rosaviatsiya sample dataset with representative regional coverage
- document the schema, units, and metric support provided by the new sample

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dbc06fc6b4832d9a8d857b81ef2872