### PR TITLE
Add base Postgres schema migration and tooling

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -67,11 +67,18 @@ docker run --rm -v twofold_build-artifacts:/artifacts busybox ls -R /artifacts
    docker compose -f infra/docker-compose.yml ps postgres
    ```
 
-3. После успешного старта выполните миграции из backend-а (конкретная команда зависит от выбранного инструмента миграций). Пример последовательности:
+3. После успешного старта примените SQL-миграции из каталога `infra/postgres/migrations/`:
 
    ```bash
-   # пример: запуск собственных миграций внутри образа backend
-   docker compose -f infra/docker-compose.yml run --rm backend-build ./scripts/migrate.sh
+   ./infra/postgres/migrate.sh
    ```
 
-   Замените `./scripts/migrate.sh` на ваш фактический CLI (например, `alembic upgrade head`, `dotnet ef database update` и т.п.).
+   Скрипт копирует миграции в контейнер `postgres` и применяет их последовательно через `psql` (с флагом `ON_ERROR_STOP`), выводя лог об успешных шагах.
+
+4. Для smoke-проверки геозапросов и годовых агрегатов выполните:
+
+   ```bash
+   ./infra/postgres/smoke.sh
+   ```
+
+   SQL-скрипт (`infra/postgres/smoke.sql`) запускает выборки с `ST_Intersects` и сверяет агрегаты `aggregates_year` с нормализованными полётами, что подтверждает корректность DoD по PostGIS и витринам.

--- a/infra/postgres/migrate.sh
+++ b/infra/postgres/migrate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATIONS_DIR="${REPO_ROOT}/infra/postgres/migrations"
+COMPOSE_FILE="${REPO_ROOT}/infra/docker-compose.yml"
+SERVICE_NAME="postgres"
+DB_NAME="${POSTGRES_DB:-bpla}"
+DB_USER="${POSTGRES_USER:-bpla_user}"
+TMP_DIR="/tmp/migrations"
+
+if [[ ! -d "${MIGRATIONS_DIR}" ]]; then
+  echo "[migrate] Migrations directory not found: ${MIGRATIONS_DIR}" >&2
+  exit 1
+fi
+
+mapfile -t migrations < <(find "${MIGRATIONS_DIR}" -maxdepth 1 -type f -name '*.sql' -print | sort)
+
+if [[ ${#migrations[@]} -eq 0 ]]; then
+  echo "[migrate] No migrations to apply."
+  exit 0
+fi
+
+echo "[migrate] Applying ${#migrations[@]} migration(s) in alphabetical order..."
+for migration in "${migrations[@]}"; do
+  filename="$(basename "${migration}")"
+  echo "[migrate] → ${filename}"
+  docker compose -f "${COMPOSE_FILE}" exec -T "${SERVICE_NAME}" \
+    bash -c "mkdir -p '${TMP_DIR}' && cat > '${TMP_DIR}/${filename}'" < "${migration}"
+  docker compose -f "${COMPOSE_FILE}" exec -T "${SERVICE_NAME}" \
+    psql -v ON_ERROR_STOP=1 -U "${DB_USER}" -d "${DB_NAME}" -f "${TMP_DIR}/${filename}"
+  docker compose -f "${COMPOSE_FILE}" exec -T "${SERVICE_NAME}" rm -f "${TMP_DIR}/${filename}"
+  echo "[migrate] ✔ ${filename} applied"
+  echo
+done
+
+echo "[migrate] All migrations applied successfully."

--- a/infra/postgres/migrations/0001_initial.sql
+++ b/infra/postgres/migrations/0001_initial.sql
@@ -1,0 +1,108 @@
+-- 0001_initial.sql
+-- Creates base schema for UAV analytics platform
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE dataset_version (
+    id              BIGSERIAL PRIMARY KEY,
+    version_name    TEXT        NOT NULL UNIQUE,
+    year            SMALLINT    NOT NULL,
+    source_uri      TEXT,
+    status          TEXT        NOT NULL DEFAULT 'new',
+    checksum        TEXT,
+    ingested_at     TIMESTAMPTZ,
+    validated_at    TIMESTAMPTZ,
+    aggregated_at   TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE regions (
+    id              BIGSERIAL PRIMARY KEY,
+    code            TEXT        NOT NULL UNIQUE,
+    name            TEXT        NOT NULL,
+    boundary        GEOMETRY(MultiPolygon, 4326) NOT NULL
+);
+
+CREATE TABLE flights_raw (
+    id                  BIGSERIAL PRIMARY KEY,
+    dataset_version_id  BIGINT      NOT NULL REFERENCES dataset_version(id) ON DELETE CASCADE,
+    region_id           BIGINT      REFERENCES regions(id),
+    flight_external_id  TEXT        NOT NULL,
+    event_date          DATE        NOT NULL,
+    year                SMALLINT    GENERATED ALWAYS AS (EXTRACT(YEAR FROM event_date)::SMALLINT) STORED,
+    month               SMALLINT    GENERATED ALWAYS AS (EXTRACT(MONTH FROM event_date)::SMALLINT) STORED,
+    payload             JSONB,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(dataset_version_id, flight_external_id)
+);
+
+CREATE TABLE flights_norm (
+    id                  BIGSERIAL PRIMARY KEY,
+    dataset_version_id  BIGINT      NOT NULL REFERENCES dataset_version(id) ON DELETE CASCADE,
+    region_id           BIGINT      REFERENCES regions(id),
+    flight_uid          TEXT        NOT NULL,
+    departure_time      TIMESTAMPTZ NOT NULL,
+    arrival_time        TIMESTAMPTZ,
+    duration_minutes    NUMERIC(10,2),
+    year                SMALLINT    GENERATED ALWAYS AS (EXTRACT(YEAR FROM departure_time)::SMALLINT) STORED,
+    month               SMALLINT    GENERATED ALWAYS AS (EXTRACT(MONTH FROM departure_time)::SMALLINT) STORED,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(dataset_version_id, flight_uid)
+);
+
+CREATE TABLE flights_geo (
+    id                  BIGSERIAL PRIMARY KEY,
+    dataset_version_id  BIGINT      NOT NULL REFERENCES dataset_version(id) ON DELETE CASCADE,
+    region_id           BIGINT      REFERENCES regions(id),
+    flight_uid          TEXT        NOT NULL,
+    location            GEOMETRY(Point, 4326) NOT NULL,
+    observed_at         TIMESTAMPTZ NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(dataset_version_id, flight_uid, observed_at)
+);
+
+CREATE TABLE aggregates_year (
+    id                  BIGSERIAL PRIMARY KEY,
+    dataset_version_id  BIGINT      NOT NULL REFERENCES dataset_version(id) ON DELETE CASCADE,
+    region_id           BIGINT      NOT NULL REFERENCES regions(id),
+    year                SMALLINT    NOT NULL,
+    flights_count       BIGINT      NOT NULL DEFAULT 0,
+    duration_sum_min    NUMERIC(12,2) NOT NULL DEFAULT 0,
+    duration_avg_min    NUMERIC(10,2),
+    payload             JSONB,
+    UNIQUE(dataset_version_id, region_id, year)
+);
+
+CREATE TABLE quality_report (
+    id                  BIGSERIAL PRIMARY KEY,
+    dataset_version_id  BIGINT      NOT NULL REFERENCES dataset_version(id) ON DELETE CASCADE,
+    region_id           BIGINT      REFERENCES regions(id),
+    check_name          TEXT        NOT NULL,
+    severity            TEXT        NOT NULL,
+    details             JSONB,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- B-tree indexes for search keys
+CREATE INDEX idx_flights_raw_search
+    ON flights_raw (dataset_version_id, region_id, year, month);
+
+CREATE INDEX idx_flights_norm_search
+    ON flights_norm (dataset_version_id, region_id, year, month);
+
+CREATE INDEX idx_flights_geo_search
+    ON flights_geo (dataset_version_id, region_id);
+
+CREATE INDEX idx_aggregates_year_search
+    ON aggregates_year (dataset_version_id, region_id, year);
+
+CREATE INDEX idx_quality_report_search
+    ON quality_report (dataset_version_id, region_id);
+
+-- Geospatial index
+CREATE INDEX idx_flights_geo_location
+    ON flights_geo USING GIST (location);
+
+COMMIT;

--- a/infra/postgres/smoke.sh
+++ b/infra/postgres/smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/infra/docker-compose.yml"
+SERVICE_NAME="postgres"
+DB_NAME="${POSTGRES_DB:-bpla}"
+DB_USER="${POSTGRES_USER:-bpla_user}"
+SQL_FILE="${REPO_ROOT}/infra/postgres/smoke.sql"
+TMP_FILE="/tmp/smoke.sql"
+
+if [[ ! -f "${SQL_FILE}" ]]; then
+  echo "[smoke] SQL script not found: ${SQL_FILE}" >&2
+  exit 1
+fi
+
+echo "[smoke] Running smoke checks from ${SQL_FILE}"
+docker compose -f "${COMPOSE_FILE}" exec -T "${SERVICE_NAME}" \
+  bash -c "cat > '${TMP_FILE}'" < "${SQL_FILE}"
+docker compose -f "${COMPOSE_FILE}" exec -T "${SERVICE_NAME}" \
+  psql -v ON_ERROR_STOP=1 -U "${DB_USER}" -d "${DB_NAME}" -f "${TMP_FILE}"
+docker compose -f "${COMPOSE_FILE}" exec -T "${SERVICE_NAME}" rm -f "${TMP_FILE}"
+echo "[smoke] Smoke checks completed."

--- a/infra/postgres/smoke.sql
+++ b/infra/postgres/smoke.sql
@@ -1,0 +1,31 @@
+\echo 'Smoke: ST_Intersects between flights and region boundaries'
+SELECT COUNT(*) AS intersected
+FROM flights_geo fg
+JOIN regions r ON r.id = fg.region_id
+WHERE ST_Intersects(fg.location, r.boundary);
+
+\echo 'Smoke: Yearly aggregates sample'
+SELECT dataset_version_id,
+       region_id,
+       year,
+       flights_count,
+       duration_sum_min,
+       duration_avg_min
+FROM aggregates_year
+ORDER BY dataset_version_id, region_id, year
+LIMIT 10;
+
+\echo 'Smoke: Aggregates vs normalized flights'
+SELECT a.dataset_version_id,
+       a.region_id,
+       a.year,
+       a.flights_count,
+       COUNT(fn.id) AS normalized_flights
+FROM aggregates_year a
+LEFT JOIN flights_norm fn
+  ON fn.dataset_version_id = a.dataset_version_id
+ AND fn.region_id = a.region_id
+ AND fn.year = a.year
+GROUP BY a.dataset_version_id, a.region_id, a.year, a.flights_count
+ORDER BY a.dataset_version_id, a.region_id, a.year
+LIMIT 10;


### PR DESCRIPTION
## Summary
- add the initial Postgres migration defining dataset, flight, aggregate and quality tables with indexes
- add helper scripts to apply migrations and run smoke checks against the postgres container
- document the workflow for running migrations and smoke tests in the infrastructure README

## Testing
- not run (infrastructure scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68dd0f551ca0832d9a4792f48a725f0a