### PR TITLE
Add ingest agent packaging and CLI

### DIFF
--- a/agents/ingest/Dockerfile
+++ b/agents/ingest/Dockerfile
@@ -6,14 +6,27 @@ FROM ${BASE_IMAGE} AS base
 ARG COMPONENT_NAME=agent-ingest
 ENV COMPONENT_NAME=${COMPONENT_NAME} \
     ARTIFACTS_DIR=/artifacts \
-    CACHE_DIR=/cache
+    CACHE_DIR=/cache \
+    PIP_CACHE_DIR=/cache/pip
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libmagic1 \
+        poppler-utils \
+        ghostscript \
+        libxml2 \
+        libxslt1.1 \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 
-COPY scripts ./scripts
-RUN chmod +x ./scripts/*.sh
-
 COPY . .
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-cache-dir .
+
+RUN chmod +x ./scripts/*.sh
 
 FROM base AS lint
 CMD ["./scripts/lint.sh"]
@@ -26,3 +39,7 @@ CMD ["./scripts/build.sh"]
 
 FROM base AS publish
 CMD ["./scripts/publish.sh"]
+
+FROM base AS runtime
+ENTRYPOINT ["python", "-m", "app.cli"]
+CMD ["--help"]

--- a/agents/ingest/LICENSE
+++ b/agents/ingest/LICENSE
@@ -1,0 +1,2 @@
+This project is distributed under the same terms as the root repository license.
+See the file located two directories above this one.

--- a/agents/ingest/app/__init__.py
+++ b/agents/ingest/app/__init__.py
@@ -1,0 +1,15 @@
+"""Ingest agent application package."""
+
+from .config import AppSettings, MinioSettings, PostgresSettings, StorageSettings
+from .logging import configure_logging, get_logger
+from .pipeline import IngestPipeline
+
+__all__ = [
+    "AppSettings",
+    "MinioSettings",
+    "PostgresSettings",
+    "StorageSettings",
+    "IngestPipeline",
+    "configure_logging",
+    "get_logger",
+]

--- a/agents/ingest/app/__main__.py
+++ b/agents/ingest/app/__main__.py
@@ -1,0 +1,13 @@
+"""Entry point for running the ingest CLI as a module."""
+
+from .cli import app
+
+
+def main() -> None:
+    """Execute the Typer application."""
+
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/ingest/app/cli.py
+++ b/agents/ingest/app/cli.py
@@ -1,0 +1,85 @@
+"""Command-line interface for the ingest agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .config import AppSettings
+from .logging import configure_logging, get_logger
+from .pipeline import IngestPipeline
+
+app = typer.Typer(add_completion=False, no_args_is_help=True, rich_markup_mode="markdown")
+
+
+@app.callback()
+def init() -> None:
+    """Initialize application-wide services before command execution."""
+
+    configure_logging()
+
+
+@app.command(help="Run the ingest pipeline for the given data source.")
+def ingest(
+    source: str = typer.Argument(..., help="Name of the data source to ingest."),
+    year: Optional[int] = typer.Option(
+        None,
+        "--year",
+        "-y",
+        help="Target year for the ingest run.",
+    ),
+    fmt: Optional[str] = typer.Option(
+        None,
+        "--format",
+        "-f",
+        help="Explicit source format override (e.g. csv, xls).",
+    ),
+    storage_path: Optional[Path] = typer.Option(
+        None,
+        "--storage-path",
+        "-s",
+        help="Custom path in the storage backend where the dataset should be written.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Perform all preparation steps without persisting results.",
+    ),
+    dataset_version: Optional[str] = typer.Option(
+        None,
+        "--dataset-version",
+        help="Override the dataset version stored in configuration.",
+    ),
+) -> None:
+    """Execute the ingest pipeline with the provided parameters."""
+
+    settings = AppSettings()
+    pipeline = IngestPipeline(settings=settings)
+    logger = get_logger("app.cli")
+
+    context = {
+        "source": source,
+        "year": year,
+        "format": fmt,
+        "storage_path": str(storage_path) if storage_path else None,
+        "dry_run": dry_run,
+        "dataset_version": dataset_version or settings.dataset_version,
+    }
+    logger.info("Starting ingest command", extra={"context": context})
+
+    pipeline.run(
+        source,
+        year=year,
+        fmt=fmt,
+        storage_path=storage_path,
+        dry_run=dry_run,
+        dataset_version=dataset_version,
+    )
+
+    logger.info("Finished ingest command", extra={"context": context})
+
+
+if __name__ == "__main__":
+    app()

--- a/agents/ingest/app/config.py
+++ b/agents/ingest/app/config.py
@@ -1,0 +1,86 @@
+"""Application configuration models loaded from environment variables."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class PostgresSettings(BaseSettings):
+    """Connection parameters for the Postgres database."""
+
+    host: str = "localhost"
+    port: int = 5432
+    database: str = "postgres"
+    user: str = "postgres"
+    password: str = ""
+    sslmode: Optional[str] = None
+
+    model_config = SettingsConfigDict(env_prefix="POSTGRES_", extra="ignore")
+
+
+class MinioSettings(BaseSettings):
+    """Configuration for connecting to the MinIO/S3-compatible storage."""
+
+    endpoint: str = "localhost:9000"
+    access_key: str = ""
+    secret_key: str = ""
+    region: Optional[str] = None
+    bucket: Optional[str] = None
+    secure: bool = False
+
+    model_config = SettingsConfigDict(env_prefix="MINIO_", extra="ignore")
+
+
+class StorageSettings(BaseSettings):
+    """Dataset storage configuration used by the ingest pipeline."""
+
+    dataset_root: Optional[Path] = Field(
+        default=None,
+        validation_alias=AliasChoices("DATASET_ROOT", "STORAGE__DATASET_ROOT"),
+    )
+    dataset_bucket: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("DATASET_BUCKET", "STORAGE__DATASET_BUCKET"),
+    )
+    dataset_version: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("DATASET_VERSION", "STORAGE__DATASET_VERSION"),
+    )
+    dataset_prefix: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("DATASET_PREFIX", "STORAGE__DATASET_PREFIX"),
+    )
+    default_format: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("DATASET_FORMAT", "STORAGE__DEFAULT_FORMAT"),
+    )
+
+    model_config = SettingsConfigDict(extra="ignore")
+
+
+class AppSettings(BaseSettings):
+    """Top-level application configuration container."""
+
+    environment: str = Field(default="development", validation_alias=AliasChoices("ENVIRONMENT"))
+    default_year: Optional[int] = Field(default=None, validation_alias=AliasChoices("DEFAULT_YEAR"))
+    postgres: PostgresSettings = Field(default_factory=PostgresSettings)
+    minio: MinioSettings = Field(default_factory=MinioSettings)
+    storage: StorageSettings = Field(default_factory=StorageSettings)
+
+    model_config = SettingsConfigDict(env_nested_delimiter="__", extra="ignore")
+
+    @property
+    def dataset_root(self) -> Optional[Path]:
+        """Shortcut to the configured dataset root path."""
+
+        return self.storage.dataset_root
+
+    @property
+    def dataset_version(self) -> Optional[str]:
+        """Return the default dataset version if defined."""
+
+        return self.storage.dataset_version

--- a/agents/ingest/app/logging.py
+++ b/agents/ingest/app/logging.py
@@ -1,0 +1,34 @@
+"""Logging helpers for the ingest application."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from rich.console import Console
+from rich.logging import RichHandler
+
+_LOGGING_CONFIGURED = False
+
+
+def configure_logging(level: str | int = "INFO") -> None:
+    """Configure application-wide logging with a Rich handler."""
+
+    global _LOGGING_CONFIGURED
+    if _LOGGING_CONFIGURED:
+        return
+
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler(console=Console(stderr=True), rich_tracebacks=True)],
+    )
+    _LOGGING_CONFIGURED = True
+
+
+def get_logger(name: Optional[str] = None, level: str | int = "INFO") -> logging.Logger:
+    """Return a logger instance, configuring logging if necessary."""
+
+    configure_logging(level)
+    return logging.getLogger(name or "app")

--- a/agents/ingest/app/pipeline.py
+++ b/agents/ingest/app/pipeline.py
@@ -1,0 +1,53 @@
+"""Core ingest pipeline implementation stub."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .config import AppSettings
+from .logging import get_logger
+
+
+class IngestPipeline:
+    """High-level pipeline orchestrating ingest steps."""
+
+    def __init__(self, settings: Optional[AppSettings] = None) -> None:
+        self.settings = settings or AppSettings()
+        self.logger = get_logger("app.pipeline")
+
+    def run(
+        self,
+        source: str,
+        *,
+        year: Optional[int] = None,
+        fmt: Optional[str] = None,
+        storage_path: Optional[Path] = None,
+        dry_run: bool = False,
+        dataset_version: Optional[str] = None,
+    ) -> None:
+        """Execute the ingest pipeline for the provided source."""
+
+        resolved_version = dataset_version or self.settings.dataset_version
+        target_path = storage_path or self.settings.dataset_root
+        context = {
+            "source": source,
+            "year": year,
+            "format": fmt,
+            "storage_path": str(target_path) if target_path else None,
+            "dry_run": dry_run,
+            "dataset_version": resolved_version,
+        }
+
+        self.logger.info("Starting ingest pipeline", extra={"context": context})
+
+        if dry_run:
+            self.logger.info(
+                "Dry run enabled, skipping dataset persistence.",
+                extra={"context": context},
+            )
+
+        # Placeholder for the actual ingest logic.
+        self.logger.debug("Pipeline configuration", extra={"context": self.settings.model_dump()})
+
+        self.logger.info("Finished ingest pipeline", extra={"context": context})

--- a/agents/ingest/pyproject.toml
+++ b/agents/ingest/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["hatchling>=1.21"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-ingest"
+version = "0.1.0"
+description = "Ingest agent command-line utilities and pipeline."
+readme = "README.md"
+authors = [{ name = "Twofold" }]
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+dependencies = [
+  "typer>=0.9",
+  "pydantic-settings>=2.2",
+  "pandas>=2.0",
+  "polars>=0.20",
+  "pyarrow>=14.0",
+  "duckdb>=0.9",
+  "psycopg[binary]>=3.1",
+  "boto3>=1.28",
+  "minio>=7.1",
+  "python-dateutil>=2.8",
+  "pendulum>=3.0",
+  "rich>=13.0",
+  "pytest>=7.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "app",
+  "README.md",
+  "LICENSE",
+  "pyproject.toml",
+  "tests",
+]
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+packages = ["app"]

--- a/agents/ingest/scripts/build.sh
+++ b/agents/ingest/scripts/build.sh
@@ -1,41 +1,19 @@
 #!/usr/bin/env sh
-set -eu
+set -euo pipefail
 
 : "${COMPONENT_NAME:=agent-ingest}"
 : "${ARTIFACTS_DIR:=/artifacts}"
 : "${CACHE_DIR:=/cache}"
 
-mkdir -p "${ARTIFACTS_DIR}" "${CACHE_DIR}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+PROJECT_DIR="$(dirname -- "${SCRIPT_DIR}")"
+PIP_CACHE_DIR="${CACHE_DIR}/pip"
 
-case "$(basename "$0")" in
-  lint.sh)
-    echo "Running lint for ${COMPONENT_NAME} (skeleton)."
-    printf 'lint_ok=true\ncomponent=%s\n' "${COMPONENT_NAME}" \
-      > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_lint.log"
-    ;;
-  test.sh)
-    echo "Executing placeholder unit tests for ${COMPONENT_NAME}."
-    cat <<XML > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_tests.xml"
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="${COMPONENT_NAME}" tests="1" failures="0">
-  <testcase classname="placeholder" name="succeeds"/>
-</testsuite>
-XML
-    ;;
-  build.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_build.txt"
-    echo "Building ${COMPONENT_NAME} (placeholder)." | tee "${artifact}"
-    printf 'artifact=%s\n' "${artifact}" >> "${artifact}"
-    ;;
-  publish.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_publish.log"
-    {
-      echo "Publishing ${COMPONENT_NAME} (placeholder)."
-      echo "timestamp=$(date -u +%FT%TZ)"
-    } > "${artifact}"
-    ;;
-  *)
-    echo "Unknown script $(basename "$0")" >&2
-    exit 1
-    ;;
-esac
+mkdir -p "${ARTIFACTS_DIR}" "${PIP_CACHE_DIR}"
+
+cd "${PROJECT_DIR}"
+
+python -m pip install --cache-dir "${PIP_CACHE_DIR}" --upgrade pip >/dev/null
+python -m pip install --cache-dir "${PIP_CACHE_DIR}" --upgrade . build >/dev/null
+
+python -m build --outdir "${ARTIFACTS_DIR}"

--- a/agents/ingest/scripts/publish.sh
+++ b/agents/ingest/scripts/publish.sh
@@ -1,41 +1,25 @@
 #!/usr/bin/env sh
-set -eu
+set -euo pipefail
 
 : "${COMPONENT_NAME:=agent-ingest}"
 : "${ARTIFACTS_DIR:=/artifacts}"
 : "${CACHE_DIR:=/cache}"
 
-mkdir -p "${ARTIFACTS_DIR}" "${CACHE_DIR}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+PROJECT_DIR="$(dirname -- "${SCRIPT_DIR}")"
+PIP_CACHE_DIR="${CACHE_DIR}/pip"
 
-case "$(basename "$0")" in
-  lint.sh)
-    echo "Running lint for ${COMPONENT_NAME} (skeleton)."
-    printf 'lint_ok=true\ncomponent=%s\n' "${COMPONENT_NAME}" \
-      > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_lint.log"
-    ;;
-  test.sh)
-    echo "Executing placeholder unit tests for ${COMPONENT_NAME}."
-    cat <<XML > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_tests.xml"
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="${COMPONENT_NAME}" tests="1" failures="0">
-  <testcase classname="placeholder" name="succeeds"/>
-</testsuite>
-XML
-    ;;
-  build.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_build.txt"
-    echo "Building ${COMPONENT_NAME} (placeholder)." | tee "${artifact}"
-    printf 'artifact=%s\n' "${artifact}" >> "${artifact}"
-    ;;
-  publish.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_publish.log"
-    {
-      echo "Publishing ${COMPONENT_NAME} (placeholder)."
-      echo "timestamp=$(date -u +%FT%TZ)"
-    } > "${artifact}"
-    ;;
-  *)
-    echo "Unknown script $(basename "$0")" >&2
-    exit 1
-    ;;
-esac
+mkdir -p "${ARTIFACTS_DIR}" "${PIP_CACHE_DIR}"
+
+cd "${PROJECT_DIR}"
+
+python -m pip install --cache-dir "${PIP_CACHE_DIR}" --upgrade pip >/dev/null
+python -m pip install --cache-dir "${PIP_CACHE_DIR}" --upgrade . >/dev/null
+
+publish_log="${ARTIFACTS_DIR}/${COMPONENT_NAME}_publish.log"
+{
+  echo "component=${COMPONENT_NAME}"
+  echo "timestamp=$(date -u +%FT%TZ)"
+  echo "status=skipped"
+  echo "message=Publishing is handled by the CI/CD pipeline."
+} > "${publish_log}"

--- a/agents/ingest/scripts/test.sh
+++ b/agents/ingest/scripts/test.sh
@@ -1,41 +1,21 @@
 #!/usr/bin/env sh
-set -eu
+set -euo pipefail
 
 : "${COMPONENT_NAME:=agent-ingest}"
 : "${ARTIFACTS_DIR:=/artifacts}"
 : "${CACHE_DIR:=/cache}"
 
-mkdir -p "${ARTIFACTS_DIR}" "${CACHE_DIR}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+PROJECT_DIR="$(dirname -- "${SCRIPT_DIR}")"
+PIP_CACHE_DIR="${CACHE_DIR}/pip"
 
-case "$(basename "$0")" in
-  lint.sh)
-    echo "Running lint for ${COMPONENT_NAME} (skeleton)."
-    printf 'lint_ok=true\ncomponent=%s\n' "${COMPONENT_NAME}" \
-      > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_lint.log"
-    ;;
-  test.sh)
-    echo "Executing placeholder unit tests for ${COMPONENT_NAME}."
-    cat <<XML > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_tests.xml"
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="${COMPONENT_NAME}" tests="1" failures="0">
-  <testcase classname="placeholder" name="succeeds"/>
-</testsuite>
-XML
-    ;;
-  build.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_build.txt"
-    echo "Building ${COMPONENT_NAME} (placeholder)." | tee "${artifact}"
-    printf 'artifact=%s\n' "${artifact}" >> "${artifact}"
-    ;;
-  publish.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_publish.log"
-    {
-      echo "Publishing ${COMPONENT_NAME} (placeholder)."
-      echo "timestamp=$(date -u +%FT%TZ)"
-    } > "${artifact}"
-    ;;
-  *)
-    echo "Unknown script $(basename "$0")" >&2
-    exit 1
-    ;;
-esac
+mkdir -p "${ARTIFACTS_DIR}" "${PIP_CACHE_DIR}"
+
+cd "${PROJECT_DIR}"
+
+python -m pip install --cache-dir "${PIP_CACHE_DIR}" --upgrade pip >/dev/null
+python -m pip install --cache-dir "${PIP_CACHE_DIR}" --upgrade . pytest >/dev/null
+
+junit_report="${ARTIFACTS_DIR}/${COMPONENT_NAME}_tests.xml"
+
+python -m pytest --junitxml "${junit_report}"

--- a/agents/ingest/tests/test_cli.py
+++ b/agents/ingest/tests/test_cli.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import logging
+
+from typer.testing import CliRunner
+
+from app.cli import app
+from app.pipeline import IngestPipeline
+
+
+runner = CliRunner()
+
+
+def test_help_output() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "ingest" in result.output
+
+
+def test_ingest_command_invokes_pipeline(monkeypatch, caplog) -> None:  # type: ignore[no-untyped-def]
+    captured: Dict[str, Any] = {}
+
+    def fake_run(
+        self: IngestPipeline,
+        source: str,
+        *,
+        year: int | None,
+        fmt: str | None,
+        storage_path: Path | None,
+        dry_run: bool,
+        dataset_version: str | None,
+    ) -> None:
+        captured.update(
+            {
+                "source": source,
+                "year": year,
+                "format": fmt,
+                "storage_path": storage_path,
+                "dry_run": dry_run,
+                "dataset_version": dataset_version,
+            }
+        )
+
+    monkeypatch.setattr(IngestPipeline, "run", fake_run)
+
+    caplog.set_level(logging.INFO)
+
+    result = runner.invoke(
+        app,
+        [
+            "ingest",
+            "rosaviatsia",
+            "--year",
+            "2022",
+            "--format",
+            "csv",
+            "--storage-path",
+            "/tmp/data",
+            "--dry-run",
+            "--dataset-version",
+            "v1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "source": "rosaviatsia",
+        "year": 2022,
+        "format": "csv",
+        "storage_path": Path("/tmp/data"),
+        "dry_run": True,
+        "dataset_version": "v1",
+    }
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Starting ingest command" in messages
+    assert "Finished ingest command" in messages


### PR DESCRIPTION
## Summary
- add a Hatch-based Python package for the ingest agent with configuration, logging, and pipeline scaffolding
- expose a Typer-powered CLI entry point and module runner for the ingest pipeline
- refresh local scripts, Dockerfile, and tests to install the package and validate the CLI behaviour

## Testing
- python -m pytest agents/ingest/tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dd131dc7ec832d8bc25c4b1cb6d761