### PR TITLE
Implement ingest persistence and storage pipeline

### DIFF
--- a/agents/ingest/app/lineage.py
+++ b/agents/ingest/app/lineage.py
@@ -1,0 +1,92 @@
+"""Lineage report generation for ingest runs."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import polars as pl
+import pyarrow as pa
+
+from .storage import StorageClient
+
+
+@dataclass(slots=True)
+class LineageRecorder:
+    """Collect lineage information and persist it to object storage."""
+
+    storage: StorageClient
+    schema_version: str = "1.0"
+
+    def record(
+        self,
+        *,
+        source: str,
+        year: int,
+        version: str,
+        raw_data: pl.DataFrame | pa.Table | None,
+        normalized: pa.Table,
+        counters: Dict[str, int],
+        raw_uri: str,
+        normalized_uri: str,
+        prefix: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build and persist lineage data returning the payload."""
+
+        checksum = compute_file_checksum(source)
+        raw_df = ensure_polars(raw_data)
+        norm_df = ensure_polars(normalized)
+        valid_df = norm_df.filter(~pl.col("superseded")) if "superseded" in norm_df.columns else norm_df
+
+        lineage_uri = self.storage.build_uri(year, version, "lineage", "json", prefix=prefix)
+        payload: Dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "source": {
+                "path": str(source),
+                "checksum": checksum,
+            },
+            "counts": {
+                "raw": int(raw_df.height),
+                "normalized": int(norm_df.height),
+                "valid": int(valid_df.height),
+                "invalid": int(counters.get("invalid", 0)),
+                "duplicates": int(counters.get("duplicates", 0)),
+            },
+            "artifacts": {
+                "raw": raw_uri,
+                "normalized": normalized_uri,
+                "lineage": lineage_uri,
+            },
+        }
+        self.storage.upload_json(year, version, "lineage", payload, prefix=prefix)
+        payload["uri"] = lineage_uri
+        payload["checksum"] = checksum
+        return payload
+
+
+def ensure_polars(data: pl.DataFrame | pa.Table | None) -> pl.DataFrame:
+    """Convert arbitrary tabular data to a Polars DataFrame."""
+
+    if data is None:
+        return pl.DataFrame()
+    if isinstance(data, pl.DataFrame):
+        return data
+    return pl.from_arrow(data)
+
+
+def compute_file_checksum(path: str | Path, chunk_size: int = 1024 * 1024) -> str:
+    """Calculate SHA256 checksum for the provided file path."""
+
+    file_path = Path(path)
+    if not file_path.exists():
+        return ""
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/agents/ingest/app/pipeline.py
+++ b/agents/ingest/app/pipeline.py
@@ -1,19 +1,26 @@
-"""Core ingest pipeline implementation stub."""
+"""Core ingest pipeline implementation."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional, Tuple
 
+import pendulum
+import polars as pl
 import pyarrow as pa
 
 from .config import AppSettings
 from .formats import detect_format, load_records
+from .lineage import LineageRecorder, ensure_polars as ensure_polars_df
 from .logging import get_logger
 from .normalization import normalize_records
+from .repository import DatabaseRepository
+from .storage import StorageClient
 
 
 class IngestPipeline:
+    _VERSION_FORMAT = "YYYYMMDD-HHmmss"
+
     """High-level pipeline orchestrating ingest steps."""
 
     def __init__(self, settings: Optional[AppSettings] = None) -> None:
@@ -55,12 +62,114 @@ class IngestPipeline:
         load_result = load_records(source, format_hint=detected_format)
         table, counters = normalize_records(load_result)
 
+        resolved_version = resolved_version or self._generate_version()
+        raw_df = ensure_polars_df(getattr(load_result, "records", None))
+        inferred_year = year or self._infer_year(table) or self.settings.default_year
+        if inferred_year is None and not dry_run:
+            raise ValueError("Year must be provided or derivable for persistence")
+
+        storage_prefix = str(storage_path).strip("/") if storage_path else None
+
         self.logger.info(
             "Loaded records",
-            extra={"context": {**context, "format": detected_format, **counters}},
+            extra={"context": {**context, "format": detected_format, **counters, "dataset_version": resolved_version, "year": inferred_year}},
         )
+
+        artifacts: dict[str, str] = {}
+        checksum = ""
+        dataset_version_id: int | None = None
+
+        if not dry_run:
+            if inferred_year is None:
+                raise ValueError("Year must be provided for persistence")
+            repo = DatabaseRepository(self.settings.postgres)
+            storage = StorageClient.from_settings(self.settings)
+            lineage = LineageRecorder(storage)
+
+            with repo.connection() as conn:
+                dataset_version_id = repo.create_dataset_version(
+                    conn,
+                    version_name=resolved_version,
+                    year=int(inferred_year),
+                    source_uri=str(source),
+                )
+                repo.copy_flights_raw(conn, dataset_version_id=dataset_version_id, table=table)
+                repo.upsert_flights_norm(conn, dataset_version_id=dataset_version_id, table=table)
+
+            raw_uri = storage.upload_csv(
+                int(inferred_year),
+                resolved_version,
+                "raw",
+                raw_df,
+                prefix=storage_prefix,
+            )
+            normalized_uri = storage.upload_parquet(
+                int(inferred_year),
+                resolved_version,
+                "normalized",
+                table,
+                prefix=storage_prefix,
+            )
+            lineage_payload = lineage.record(
+                source=str(source),
+                year=int(inferred_year),
+                version=resolved_version,
+                raw_data=raw_df,
+                normalized=table,
+                counters=counters,
+                raw_uri=raw_uri,
+                normalized_uri=normalized_uri,
+                prefix=storage_prefix,
+            )
+            artifacts = {
+                "raw": raw_uri,
+                "normalized": normalized_uri,
+                "lineage": lineage_payload.get("uri", ""),
+            }
+            checksum = lineage_payload.get("checksum", "")
+
+            with repo.connection() as conn:
+                repo.mark_ingested(
+                    conn,
+                    dataset_version_id=dataset_version_id,
+                    checksum=checksum,
+                    artifacts=artifacts,
+                )
 
         self.logger.debug("Pipeline configuration", extra={"context": self.settings.model_dump()})
 
-        self.logger.info("Finished ingest pipeline", extra={"context": context})
+        result_context = {
+            **context,
+            "dataset_version": resolved_version,
+            "year": inferred_year,
+            "dataset_version_id": dataset_version_id,
+            "artifacts": artifacts,
+            "checksum": checksum,
+        }
+        self.logger.info("Finished ingest pipeline", extra={"context": result_context})
         return table, counters
+
+    def _generate_version(self) -> str:
+        """Generate dataset version identifier when not provided."""
+
+        return pendulum.now("UTC").format(self._VERSION_FORMAT)
+
+    def _infer_year(self, table: pa.Table) -> Optional[int]:
+        """Infer dataset year from the normalized Arrow table."""
+
+        if table.num_rows == 0:
+            return None
+        if "start_time_utc" not in table.column_names:
+            return None
+        df = pl.from_arrow(table)
+        if "superseded" in df.columns:
+            df = df.filter(~pl.col("superseded"))
+        if df.is_empty():
+            return None
+        try:
+            year_series = df.select(pl.col("start_time_utc").dt.year().drop_nulls()).to_series()
+            if year_series.is_empty():
+                return None
+            return int(year_series.item())
+        except Exception:  # pragma: no cover - best effort
+            return None

--- a/agents/ingest/app/repository.py
+++ b/agents/ingest/app/repository.py
@@ -1,0 +1,209 @@
+"""Database persistence utilities for the ingest pipeline."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Dict, Iterator, Optional
+
+import polars as pl
+import pyarrow as pa
+from psycopg import Connection, connect
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from .config import PostgresSettings
+
+
+@dataclass(slots=True)
+class DatabaseRepository:
+    """Helper providing high-level persistence operations."""
+
+    settings: PostgresSettings
+
+    def _connection_kwargs(self) -> Dict[str, object]:
+        kwargs: Dict[str, object] = {
+            "host": self.settings.host,
+            "port": self.settings.port,
+            "dbname": self.settings.database,
+            "user": self.settings.user,
+        }
+        if self.settings.password:
+            kwargs["password"] = self.settings.password
+        if self.settings.sslmode:
+            kwargs["sslmode"] = self.settings.sslmode
+        return kwargs
+
+    @contextmanager
+    def connection(self) -> Iterator[Connection]:
+        """Context manager returning a psycopg connection with transaction handling."""
+
+        conn = connect(**self._connection_kwargs())
+        try:
+            yield conn
+            conn.commit()
+        except Exception:  # pragma: no cover - defensive rollback
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _ensure_artifacts_column(self, conn: Connection) -> None:
+        """Ensure auxiliary metadata columns exist (idempotent)."""
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                ALTER TABLE dataset_version
+                ADD COLUMN IF NOT EXISTS artifacts JSONB
+                """
+            )
+
+    def create_dataset_version(
+        self,
+        conn: Connection,
+        *,
+        version_name: str,
+        year: int,
+        source_uri: Optional[str],
+        status: str = "new",
+    ) -> int:
+        """Insert a new dataset_version row and return its id."""
+
+        if year is None:
+            raise ValueError("year must be provided for dataset_version")
+        self._ensure_artifacts_column(conn)
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                INSERT INTO dataset_version (version_name, year, source_uri, status)
+                VALUES (%s, %s, %s, %s)
+                RETURNING id
+                """,
+                (version_name, year, source_uri, status),
+            )
+            row = cur.fetchone()
+            if not row:  # pragma: no cover - should not happen
+                raise RuntimeError("Failed to insert dataset_version")
+            return int(row["id"])
+
+    def copy_flights_raw(
+        self,
+        conn: Connection,
+        *,
+        dataset_version_id: int,
+        table: pa.Table,
+        only_valid: bool = True,
+    ) -> int:
+        """Bulk-copy normalized records into flights_raw staging table."""
+
+        df = pl.from_arrow(table) if not isinstance(table, pl.DataFrame) else table
+        if df.is_empty():
+            return 0
+        if only_valid and "superseded" in df.columns:
+            df = df.filter(~pl.col("superseded"))
+        if df.is_empty():
+            return 0
+
+        count = 0
+        with conn.cursor() as cur:
+            with cur.copy(
+                "COPY flights_raw (dataset_version_id, flight_external_id, event_date, payload) FROM STDIN"
+            ) as copy:
+                for row in df.iter_rows(named=True):
+                    flight_id = row.get("flight_id")
+                    if flight_id is None:
+                        continue
+                    start: datetime | None = row.get("start_time_utc")
+                    if start is None:
+                        continue
+                    payload = _serialize_payload(row)
+                    copy.write_row(
+                        (
+                            dataset_version_id,
+                            flight_id,
+                            start.date(),
+                            Jsonb(payload),
+                        )
+                    )
+                    count += 1
+        return count
+
+    def upsert_flights_norm(
+        self,
+        conn: Connection,
+        *,
+        dataset_version_id: int,
+        table: pa.Table,
+    ) -> int:
+        """Bulk insert normalized records into flights_norm table."""
+
+        df = pl.from_arrow(table) if not isinstance(table, pl.DataFrame) else table
+        if df.is_empty():
+            return 0
+        if "superseded" in df.columns:
+            df = df.filter(~pl.col("superseded"))
+        if df.is_empty():
+            return 0
+
+        count = 0
+        with conn.cursor() as cur:
+            with cur.copy(
+                "COPY flights_norm (dataset_version_id, region_id, flight_uid, departure_time, arrival_time, duration_minutes) "
+                "FROM STDIN"
+            ) as copy:
+                for row in df.iter_rows(named=True):
+                    start: datetime | None = row.get("start_time_utc")
+                    if start is None:
+                        continue
+                    copy.write_row(
+                        (
+                            dataset_version_id,
+                            None,
+                            row.get("flight_id"),
+                            start,
+                            row.get("end_time_utc"),
+                            row.get("duration_minutes"),
+                        )
+                    )
+                    count += 1
+        return count
+
+    def mark_ingested(
+        self,
+        conn: Connection,
+        *,
+        dataset_version_id: int,
+        checksum: str,
+        artifacts: Dict[str, str],
+    ) -> None:
+        """Mark dataset_version as ingested updating checksum and artifact references."""
+
+        self._ensure_artifacts_column(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE dataset_version
+                   SET status = 'ingested',
+                       ingested_at = NOW(),
+                       checksum = %s,
+                       artifacts = %s
+                 WHERE id = %s
+                """,
+                (checksum, Jsonb(artifacts), dataset_version_id),
+            )
+
+
+def _serialize_payload(row: dict[str, object]) -> Dict[str, object]:
+    """Convert row values to JSON-serialisable types."""
+
+    payload: Dict[str, object] = {}
+    for key, value in row.items():
+        if isinstance(value, datetime):
+            payload[key] = value.isoformat()
+        elif isinstance(value, date):
+            payload[key] = value.isoformat()
+        else:
+            payload[key] = value
+    return payload

--- a/agents/ingest/app/storage.py
+++ b/agents/ingest/app/storage.py
@@ -1,0 +1,154 @@
+"""Object storage helpers for uploading ingest artifacts."""
+
+from __future__ import annotations
+
+import io
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import boto3
+import polars as pl
+import pyarrow as pa
+import pyarrow.parquet as pq
+from botocore.client import Config
+from botocore.exceptions import ClientError
+
+from .config import AppSettings, MinioSettings, StorageSettings
+
+
+@dataclass(slots=True)
+class StorageClient:
+    """Simple S3/MinIO wrapper used by the ingest pipeline."""
+
+    minio: MinioSettings
+    storage: StorageSettings
+
+    def __post_init__(self) -> None:
+        session = boto3.session.Session()
+        endpoint = self._normalize_endpoint(self.minio.endpoint)
+        use_ssl = endpoint.startswith("https://") if endpoint else self.minio.secure
+        self.client = session.client(
+            "s3",
+            endpoint_url=endpoint or None,
+            aws_access_key_id=self.minio.access_key or "minio",
+            aws_secret_access_key=self.minio.secret_key or "minio123",
+            region_name=self.minio.region or "us-east-1",
+            use_ssl=use_ssl,
+            config=Config(signature_version="s3v4"),
+        )
+        self.bucket = self.minio.bucket or self.storage.dataset_bucket or "datasets"
+        self.prefix = (self.storage.dataset_prefix or "datasets").strip("/")
+        self._ensure_bucket()
+
+    @classmethod
+    def from_settings(cls, settings: AppSettings) -> "StorageClient":
+        return cls(settings.minio, settings.storage)
+
+    def _normalize_endpoint(self, endpoint: Optional[str]) -> str:
+        if not endpoint:
+            return ""
+        if endpoint.startswith("http://") or endpoint.startswith("https://"):
+            return endpoint
+        scheme = "https" if self.minio.secure else "http"
+        return f"{scheme}://{endpoint}"
+
+    def _ensure_bucket(self) -> None:
+        try:
+            self.client.head_bucket(Bucket=self.bucket)
+        except ClientError:
+            create_kwargs: Dict[str, Any] = {"Bucket": self.bucket}
+            region = self.minio.region or "us-east-1"
+            if region != "us-east-1":
+                create_kwargs["CreateBucketConfiguration"] = {"LocationConstraint": region}
+            self.client.create_bucket(**create_kwargs)
+
+    def build_object_key(
+        self,
+        year: int,
+        version: str,
+        filename: str,
+        extension: str,
+        *,
+        prefix: Optional[str] = None,
+    ) -> str:
+        base_prefix = (prefix or self.prefix).strip("/")
+        parts = [part for part in (base_prefix, str(year), version, f"{filename}.{extension}") if part]
+        return "/".join(parts)
+
+    def build_uri(
+        self,
+        year: int,
+        version: str,
+        filename: str,
+        extension: str,
+        *,
+        prefix: Optional[str] = None,
+    ) -> str:
+        key = self.build_object_key(year, version, filename, extension, prefix=prefix)
+        return f"s3://{self.bucket}/{key}"
+
+    def upload_parquet(
+        self,
+        year: int,
+        version: str,
+        name: str,
+        table: pa.Table | pl.DataFrame,
+        *,
+        prefix: Optional[str] = None,
+    ) -> str:
+        if isinstance(table, pl.DataFrame):
+            arrow_table = table.to_arrow()
+        else:
+            arrow_table = table
+        buffer = io.BytesIO()
+        pq.write_table(arrow_table, buffer)
+        buffer.seek(0)
+        key = self.build_object_key(year, version, name, "parquet", prefix=prefix)
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=buffer.getvalue(),
+            ContentType="application/x-parquet",
+        )
+        return f"s3://{self.bucket}/{key}"
+
+    def upload_csv(
+        self,
+        year: int,
+        version: str,
+        name: str,
+        data: pa.Table | pl.DataFrame,
+        *,
+        prefix: Optional[str] = None,
+    ) -> str:
+        df = data if isinstance(data, pl.DataFrame) else pl.from_arrow(data)
+        buffer = io.StringIO()
+        df.write_csv(buffer, has_header=True)
+        key = self.build_object_key(year, version, name, "csv", prefix=prefix)
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=buffer.getvalue().encode("utf-8"),
+            ContentType="text/csv",
+        )
+        return f"s3://{self.bucket}/{key}"
+
+    def upload_json(
+        self,
+        year: int,
+        version: str,
+        name: str,
+        payload: Dict[str, Any],
+        *,
+        prefix: Optional[str] = None,
+    ) -> str:
+        key = self.build_object_key(year, version, name, "json", prefix=prefix)
+        body = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+        )
+        return f"s3://{self.bucket}/{key}"

--- a/agents/ingest/pyproject.toml
+++ b/agents/ingest/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
   "lxml>=4.9",
   "rich>=13.0",
   "pytest>=7.0",
+  "pytest-postgresql>=5.0",
+  "moto[s3]>=4.2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/agents/ingest/tests/test_pipeline.py
+++ b/agents/ingest/tests/test_pipeline.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Iterator
+
+import boto3
+import pytest
+from moto import mock_aws
+from psycopg.rows import dict_row
+from typer.testing import CliRunner
+
+from app.cli import app
+
+SAMPLES_ROOT = Path(__file__).resolve().parents[3] / "samples"
+SAMPLE_FILE = SAMPLES_ROOT / "rosaviation_sample.csv"
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def aws_client() -> Iterator[boto3.client]:
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        yield client
+
+
+@pytest.fixture()
+def migrated_db(postgresql_proc, postgresql):  # type: ignore[no-untyped-def]
+    migration_sql = (Path(__file__).resolve().parents[4] / "infra/postgres/migrations/0001_initial.sql").read_text()
+    with postgresql.cursor() as cur:
+        cur.execute(migration_sql)
+    postgresql.commit()
+    yield postgresql_proc, postgresql
+
+
+@pytest.mark.usefixtures("aws_client")
+@pytest.mark.skipif(shutil.which("pg_ctl") is None, reason="pg_ctl executable not available")
+def test_full_pipeline_ingest(monkeypatch, migrated_db):  # type: ignore[no-untyped-def]
+    proc, conn = migrated_db
+
+    monkeypatch.setenv("POSTGRES_HOST", proc.host)
+    monkeypatch.setenv("POSTGRES_PORT", str(proc.port))
+    monkeypatch.setenv("POSTGRES_DB", proc.dbname)
+    monkeypatch.setenv("POSTGRES_USER", proc.user)
+    if proc.password:
+        monkeypatch.setenv("POSTGRES_PASSWORD", proc.password)
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "test-key")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "test-secret")
+    monkeypatch.setenv("MINIO_BUCKET", "ingest-test")
+    monkeypatch.setenv("MINIO_ENDPOINT", "")
+    monkeypatch.setenv("MINIO_SECURE", "true")
+    monkeypatch.setenv("MINIO_REGION", "us-east-1")
+    monkeypatch.setenv("STORAGE__DATASET_PREFIX", "datasets")
+
+    dataset_version = "test-version"
+
+    result = runner.invoke(
+        app,
+        [
+            "ingest",
+            str(SAMPLE_FILE),
+            "--year",
+            "2024",
+            "--dataset-version",
+            dataset_version,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("SELECT id, version_name, status, checksum, artifacts FROM dataset_version")
+        dataset_row = cur.fetchone()
+        assert dataset_row is not None
+        assert dataset_row["version_name"] == dataset_version
+        assert dataset_row["status"] == "ingested"
+        assert dataset_row["checksum"]
+        artifacts = dataset_row["artifacts"]
+        assert artifacts["raw"].endswith("raw.csv")
+        assert artifacts["normalized"].endswith("normalized.parquet")
+        assert artifacts["lineage"].endswith("lineage.json")
+
+        cur.execute(
+            "SELECT COUNT(*) FROM flights_raw WHERE dataset_version_id = %s",
+            (dataset_row["id"],),
+        )
+        raw_count = cur.fetchone()[0]
+        assert raw_count == 5
+
+        cur.execute(
+            "SELECT COUNT(*) FROM flights_norm WHERE dataset_version_id = %s",
+            (dataset_row["id"],),
+        )
+        norm_count = cur.fetchone()[0]
+        assert norm_count == 5
+
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    objects = s3_client.list_objects_v2(Bucket="ingest-test")
+    keys = {item["Key"] for item in objects.get("Contents", [])}
+    expected_keys = {
+        "datasets/2024/test-version/raw.csv",
+        "datasets/2024/test-version/normalized.parquet",
+        "datasets/2024/test-version/lineage.json",
+    }
+    assert expected_keys.issubset(keys)
+
+    lineage_obj = s3_client.get_object(Bucket="ingest-test", Key="datasets/2024/test-version/lineage.json")
+    lineage_payload = json.loads(lineage_obj["Body"].read().decode("utf-8"))
+    assert lineage_payload["counts"]["raw"] == 5
+    assert lineage_payload["counts"]["normalized"] == 5
+    assert lineage_payload["artifacts"]["lineage"].endswith("lineage.json")
+    assert lineage_payload["checksum"] == dataset_row["checksum"]


### PR DESCRIPTION
## Summary
- add a repository layer to create dataset versions, bulk load flights via COPY, and mark ingested artifacts
- add a storage client and lineage recorder so the pipeline uploads CSV/Parquet artifacts, stores lineage JSON, and updates documentation
- add an integration test that exercises the CLI ingest flow with mocked S3 and optional PostgreSQL

## Testing
- pytest tests/test_pipeline.py *(skipped: pg_ctl executable not available)*

------
https://chatgpt.com/codex/tasks/task_e_68dd306a1cc8832db73a3d88c95b7eb4