### PR TITLE
Add quality validation pipeline and CLI for flight datasets

### DIFF
--- a/agents/quality/README.md
+++ b/agents/quality/README.md
@@ -1,3 +1,90 @@
 # Agent.Quality
 
-Модуль проверки качества данных: контроль схем, диапазонов, дублей, пропусков и генерация отчётов качества.
+Модуль проверки качества нормализованных данных о рейсах. Содержит пайплайн проверки, CLI и набор скриптов для локальной разработки.
+
+## Настройка окружения
+
+1. Перейдите в каталог компонента:
+   ```bash
+   cd agents/quality
+   ```
+2. Установите зависимости (рекомендуется использовать virtualenv/pyenv):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+   pip install -e .[checks]
+   ```
+   Доп. зависимость `checks` подключает Great Expectations при необходимости.
+
+## Конфигурация
+
+CLI использует переменные окружения с префиксом `QUALITY_`:
+
+| Переменная | Назначение | Значение по умолчанию |
+| --- | --- | --- |
+| `QUALITY_DATABASE_URL` | Строка подключения к Postgres | — (обязательно) |
+| `QUALITY_DATABASE_SCHEMA` | Схема БД с нормализованными рейсами | `public` |
+| `QUALITY_TABLE_NAME` | Таблица с рейсами в канонической схеме | `normalized_flights` |
+| `QUALITY_ARTIFACTS_DIR` | Директория для отчётов | `./artifacts` |
+| `QUALITY_DEFAULT_DATASET_VERSION` | Значение версии по умолчанию | `None` |
+
+## Запуск CLI
+
+Проверка конкретной версии датасета и запись отчёта:
+
+```bash
+python -m agents.quality.app.cli validate --dataset-version 2024-Q1 \
+  --output artifacts/quality_report_2024-Q1.json
+```
+
+Команда выводит итоговый статус `OK`, `WARN` или `FAIL` в stdout. Выходной код `1` возвращается только при статусе `FAIL`.
+
+Для быстрого запуска без сохранения отчёта используйте флаг `--dry-run`:
+
+```bash
+python -m agents.quality.app.cli validate --dataset-version 2024-Q1 --dry-run
+```
+
+## Интерпретация отчёта
+
+JSON-отчёт содержит список проверок с описанием и деталями:
+
+```json
+{
+  "dataset_version": "2024-Q1",
+  "generated_at": "2024-03-15T12:30:01+00:00",
+  "status": "WARN",
+  "checks": [
+    {
+      "name": "monthly_completeness",
+      "status": "WARN",
+      "summary": "missing intermediate months detected",
+      "details": {
+        "missing_months": {"2024": [2]},
+        "observed": {"2024": [1, 3]}
+      }
+    },
+    {
+      "name": "duration_range",
+      "status": "OK",
+      "summary": "all durations within expected range"
+    }
+  ]
+}
+```
+
+- `status` — агрегированный итог по всем проверкам (при наличии хотя бы одного `FAIL`).
+- `checks` — результаты индивидуальных проверок: схема, диапазоны, уникальность, полнота месяцев, выбросы.
+- Поле `details` помогает быстро локализовать проблемные строки или диапазоны.
+
+## Скрипты
+
+Для единообразных проверок доступны shell-скрипты:
+
+- `scripts/lint.sh` — запуск `ruff` и `black --check`.
+- `scripts/test.sh` — модульные тесты (`pytest`).
+- `scripts/build.sh` — сборка wheel-пакета.
+- `scripts/publish.sh` — сборка wheel и sdist в артефакты.
+
+Все команды используют переменную `ARTIFACTS_DIR` (по умолчанию `/artifacts`).

--- a/agents/quality/app/__init__.py
+++ b/agents/quality/app/__init__.py
@@ -1,0 +1,5 @@
+"""Quality assurance checks for normalized flight datasets."""
+
+from .pipeline import QualityReport, run_pipeline
+
+__all__ = ["QualityReport", "run_pipeline"]

--- a/agents/quality/app/__main__.py
+++ b/agents/quality/app/__main__.py
@@ -1,0 +1,6 @@
+"""Module entrypoint for ``python -m agents.quality.app``."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/agents/quality/app/checks/__init__.py
+++ b/agents/quality/app/checks/__init__.py
@@ -1,0 +1,38 @@
+"""Collection of quality checks."""
+
+from __future__ import annotations
+
+from .base import CheckResult, CheckStatus, DataCheck
+from .coordinate_range import CoordinateRangeCheck, build_coordinate_range_check
+from .duration_outliers import DurationOutlierCheck, build_duration_outlier_check
+from .duration_range import DurationRangeCheck, build_duration_range_check
+from .monthly_completeness import MonthlyCompletenessCheck, build_monthly_completeness_check
+from .schema import SchemaCheck, build_schema_check
+from .uniqueness import UniquenessCheck, build_uniqueness_check
+
+
+def default_checks() -> list[DataCheck]:
+    """Return the default suite of quality checks."""
+
+    return [
+        build_schema_check(),
+        build_duration_range_check(),
+        build_coordinate_range_check(),
+        build_uniqueness_check(),
+        build_monthly_completeness_check(),
+        build_duration_outlier_check(),
+    ]
+
+
+__all__ = [
+    "CheckResult",
+    "CheckStatus",
+    "DataCheck",
+    "CoordinateRangeCheck",
+    "DurationOutlierCheck",
+    "DurationRangeCheck",
+    "MonthlyCompletenessCheck",
+    "SchemaCheck",
+    "UniquenessCheck",
+    "default_checks",
+]

--- a/agents/quality/app/checks/base.py
+++ b/agents/quality/app/checks/base.py
@@ -1,0 +1,39 @@
+"""Base utilities shared by all quality checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol
+
+import pandas as pd
+
+
+class CheckStatus(str, Enum):
+    """Standardized status levels for data quality checks."""
+
+    OK = "OK"
+    WARN = "WARN"
+    FAIL = "FAIL"
+
+
+@dataclass(slots=True)
+class CheckResult:
+    """Outcome of a single check."""
+
+    name: str
+    status: CheckStatus
+    summary: str
+    details: dict[str, Any] | None = None
+
+
+class DataCheck(Protocol):
+    """Common protocol implemented by all checks."""
+
+    name: str
+
+    def run(self, data: pd.DataFrame) -> CheckResult:
+        """Validate ``data`` and return the :class:`CheckResult`."""
+
+
+__all__ = ["CheckStatus", "CheckResult", "DataCheck"]

--- a/agents/quality/app/checks/coordinate_range.py
+++ b/agents/quality/app/checks/coordinate_range.py
@@ -1,0 +1,53 @@
+"""Validate latitude/longitude ranges."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import CheckResult, CheckStatus, DataCheck
+from .utils import dataframe_to_records
+
+
+class CoordinateRangeCheck(DataCheck):
+    """Ensure latitude and longitude stay within geographic bounds."""
+
+    name = "coordinate_range"
+
+    def run(self, data: pd.DataFrame) -> CheckResult:
+        lat = data.get("latitude")
+        lon = data.get("longitude")
+        detail = {}
+
+        if lat is None or lon is None:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.WARN,
+                summary="latitude/longitude columns not available",
+            )
+
+        invalid = data[
+            (lat.notna() & ((lat < -90) | (lat > 90)))
+            | (lon.notna() & ((lon < -180) | (lon > 180)))
+        ]
+
+        if invalid.empty:
+            summary = "coordinates fall within expected bounds"
+            status = CheckStatus.OK
+        else:
+            status = CheckStatus.FAIL
+            summary = f"found {invalid.shape[0]} coordinates outside geographic bounds"
+            detail = {
+                "invalid_count": int(invalid.shape[0]),
+                "sample_rows": dataframe_to_records(invalid),
+            }
+
+        return CheckResult(name=self.name, status=status, summary=summary, details=detail or None)
+
+
+def build_coordinate_range_check() -> CoordinateRangeCheck:
+    """Factory returning a coordinate range check instance."""
+
+    return CoordinateRangeCheck()
+
+
+__all__ = ["CoordinateRangeCheck", "build_coordinate_range_check"]

--- a/agents/quality/app/checks/duration_outliers.py
+++ b/agents/quality/app/checks/duration_outliers.py
@@ -1,0 +1,67 @@
+"""Detect duration outliers using an IQR strategy."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import CheckResult, CheckStatus, DataCheck
+from .utils import dataframe_to_records
+
+
+class DurationOutlierCheck(DataCheck):
+    """Identify unusually long or short flights."""
+
+    name = "duration_outliers"
+
+    def run(self, data: pd.DataFrame) -> CheckResult:
+        if "duration_minutes" not in data.columns:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.FAIL,
+                summary="duration_minutes column missing",
+            )
+
+        durations = data["duration_minutes"].dropna()
+        if durations.empty:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.WARN,
+                summary="no duration values available for outlier detection",
+            )
+
+        q1 = durations.quantile(0.25)
+        q3 = durations.quantile(0.75)
+        iqr = q3 - q1
+        lower = q1 - 1.5 * iqr
+        upper = q3 + 1.5 * iqr
+
+        outliers = data[(data["duration_minutes"] < lower) | (data["duration_minutes"] > upper)]
+        detail = {
+            "thresholds": {"lower": float(lower), "upper": float(upper)},
+            "outlier_count": int(outliers.shape[0]),
+        }
+
+        if outliers.empty:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.OK,
+                summary="no duration outliers detected",
+                details=detail,
+            )
+
+        detail["sample_rows"] = dataframe_to_records(outliers)
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.WARN,
+            summary=f"detected {outliers.shape[0]} potential duration outliers",
+            details=detail,
+        )
+
+
+def build_duration_outlier_check() -> DurationOutlierCheck:
+    """Factory returning the duration outlier check."""
+
+    return DurationOutlierCheck()
+
+
+__all__ = ["DurationOutlierCheck", "build_duration_outlier_check"]

--- a/agents/quality/app/checks/duration_range.py
+++ b/agents/quality/app/checks/duration_range.py
@@ -1,0 +1,55 @@
+"""Validate duration ranges for flights."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import CheckResult, CheckStatus, DataCheck
+from .utils import dataframe_to_records
+
+
+class DurationRangeCheck(DataCheck):
+    """Ensure flight durations fall within realistic boundaries."""
+
+    name = "duration_range"
+
+    def __init__(self, minimum: float = 1.0, maximum: float = 24 * 60) -> None:
+        self.minimum = minimum
+        self.maximum = maximum
+
+    def run(self, data: pd.DataFrame) -> CheckResult:
+        if "duration_minutes" not in data.columns:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.FAIL,
+                summary="duration_minutes column missing",
+            )
+
+        durations = data["duration_minutes"].dropna()
+        below = durations < self.minimum
+        above = durations > self.maximum
+        invalid_rows = data[below | above]
+        detail = {
+            "minimum": self.minimum,
+            "maximum": self.maximum,
+            "invalid_count": int(invalid_rows.shape[0]),
+        }
+
+        if invalid_rows.empty:
+            summary = "all durations within expected range"
+            status = CheckStatus.OK
+        else:
+            status = CheckStatus.FAIL
+            summary = f"found {invalid_rows.shape[0]} durations outside range"
+            detail["sample_rows"] = dataframe_to_records(invalid_rows)
+
+        return CheckResult(name=self.name, status=status, summary=summary, details=detail)
+
+
+def build_duration_range_check() -> DurationRangeCheck:
+    """Factory returning a range check instance."""
+
+    return DurationRangeCheck()
+
+
+__all__ = ["DurationRangeCheck", "build_duration_range_check"]

--- a/agents/quality/app/checks/monthly_completeness.py
+++ b/agents/quality/app/checks/monthly_completeness.py
@@ -1,0 +1,73 @@
+"""Check completeness of months within each year."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import CheckResult, CheckStatus, DataCheck
+
+
+class MonthlyCompletenessCheck(DataCheck):
+    """Ensure each year contains a contiguous sequence of months."""
+
+    name = "monthly_completeness"
+
+    def run(self, data: pd.DataFrame) -> CheckResult:
+        if "start_time_utc" not in data.columns:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.FAIL,
+                summary="start_time_utc column missing",
+            )
+
+        timestamps = pd.to_datetime(data["start_time_utc"], errors="coerce")
+        invalid_dates = data[timestamps.isna()]
+        if not invalid_dates.empty:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.FAIL,
+                summary="invalid datetimes in start_time_utc",
+                details={
+                    "invalid_count": int(invalid_dates.shape[0]),
+                    "sample_rows": invalid_dates.head(5).to_dict(orient="records"),
+                },
+            )
+
+        months = timestamps.dt.month
+        years = timestamps.dt.year
+        detail: dict[str, list[int]] = {}
+        warnings: dict[int, list[int]] = {}
+
+        for year in sorted(years.unique()):
+            year_months = sorted(months[years == year].unique())
+            if not year_months:
+                continue
+            expected = set(range(min(year_months), max(year_months) + 1))
+            missing = sorted(expected.difference(year_months))
+            if missing:
+                warnings[year] = missing
+            detail[str(year)] = year_months
+
+        if warnings:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.WARN,
+                summary="missing intermediate months detected",
+                details={"missing_months": warnings, "observed": detail},
+            )
+
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.OK,
+            summary="months are contiguous within each year",
+            details={"observed": detail} if detail else None,
+        )
+
+
+def build_monthly_completeness_check() -> MonthlyCompletenessCheck:
+    """Factory returning the monthly completeness check."""
+
+    return MonthlyCompletenessCheck()
+
+
+__all__ = ["MonthlyCompletenessCheck", "build_monthly_completeness_check"]

--- a/agents/quality/app/checks/schema.py
+++ b/agents/quality/app/checks/schema.py
@@ -1,0 +1,73 @@
+"""Schema validation check."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from agents.ingest.app.schemas import CANONICAL_ORDER
+
+from .base import CheckResult, CheckStatus, DataCheck
+
+
+class SchemaCheck(DataCheck):
+    """Verify the dataframe adheres to the canonical schema."""
+
+    name = "schema"
+    _required_columns = {
+        "flight_id",
+        "start_time_utc",
+        "end_time_utc",
+        "duration_minutes",
+    }
+    _expected_columns = set(CANONICAL_ORDER)
+
+    def run(self, data: pd.DataFrame) -> CheckResult:
+        missing_columns = sorted(self._expected_columns.difference(data.columns))
+        unexpected_columns = sorted(set(data.columns).difference(self._expected_columns))
+
+        detail: dict[str, Any] = {}
+        status = CheckStatus.OK
+        messages: list[str] = []
+
+        if missing_columns:
+            status = CheckStatus.FAIL
+            detail["missing_columns"] = missing_columns
+            messages.append("missing required columns")
+
+        if unexpected_columns:
+            detail["unexpected_columns"] = unexpected_columns
+            if status is CheckStatus.OK:
+                status = CheckStatus.WARN
+            messages.append("found unexpected columns")
+
+        null_counts = {
+            column: int(data[column].isna().sum())
+            for column in self._required_columns
+            if column in data.columns
+        }
+        null_violations = {col: count for col, count in null_counts.items() if count > 0}
+        if null_violations:
+            status = CheckStatus.FAIL
+            detail["null_counts"] = null_violations
+            messages.append("null values detected in required columns")
+
+        if not messages:
+            messages.append("schema matches canonical definition")
+
+        return CheckResult(
+            name=self.name,
+            status=status,
+            summary="; ".join(messages),
+            details=detail or None,
+        )
+
+
+def build_schema_check() -> SchemaCheck:
+    """Factory returning a schema check instance."""
+
+    return SchemaCheck()
+
+
+__all__ = ["SchemaCheck", "build_schema_check"]

--- a/agents/quality/app/checks/uniqueness.py
+++ b/agents/quality/app/checks/uniqueness.py
@@ -1,0 +1,52 @@
+"""Uniqueness check for normalized flights."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import CheckResult, CheckStatus, DataCheck
+from .utils import dataframe_to_records
+
+
+class UniquenessCheck(DataCheck):
+    """Validate uniqueness of key dimensions."""
+
+    name = "uniqueness"
+    _key_columns = ("flight_id", "start_time_utc", "region_code")
+
+    def run(self, data: pd.DataFrame) -> CheckResult:
+        missing = [col for col in self._key_columns if col not in data.columns]
+        if missing:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.FAIL,
+                summary=f"missing key columns: {', '.join(missing)}",
+            )
+
+        duplicates = data.duplicated(subset=list(self._key_columns), keep=False)
+        duplicate_rows = data[duplicates]
+        if duplicate_rows.empty:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.OK,
+                summary="primary key combination is unique",
+            )
+
+        return CheckResult(
+            name=self.name,
+            status=CheckStatus.FAIL,
+            summary=f"found {duplicate_rows.shape[0]} duplicate key rows",
+            details={
+                "duplicate_count": int(duplicate_rows.shape[0]),
+                "sample_rows": dataframe_to_records(duplicate_rows),
+            },
+        )
+
+
+def build_uniqueness_check() -> UniquenessCheck:
+    """Factory returning uniqueness check instance."""
+
+    return UniquenessCheck()
+
+
+__all__ = ["UniquenessCheck", "build_uniqueness_check"]

--- a/agents/quality/app/checks/utils.py
+++ b/agents/quality/app/checks/utils.py
@@ -1,0 +1,22 @@
+"""Utility helpers for check implementations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def dataframe_to_records(frame: pd.DataFrame, limit: int = 5) -> list[dict[str, Any]]:
+    """Convert a dataframe slice into JSON-serialisable records."""
+
+    serialisable = frame.head(limit).copy()
+    for column in serialisable.select_dtypes(include=["datetime", "datetimetz"]).columns:
+        series = serialisable[column]
+        if series.dt.tz is None:
+            series = series.dt.tz_localize("UTC")
+        serialisable[column] = series.dt.tz_convert("UTC").dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return serialisable.where(pd.notna(serialisable), None).to_dict(orient="records")
+
+
+__all__ = ["dataframe_to_records"]

--- a/agents/quality/app/cli.py
+++ b/agents/quality/app/cli.py
@@ -1,0 +1,70 @@
+"""Command line interface for the quality validation agent."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .config import QualitySettings, get_settings
+from .logging import configure_logging, get_logger
+from .pipeline import QualityReport, run_pipeline
+
+app = typer.Typer(help="Quality validation utilities for normalized flights.")
+LOGGER = get_logger(__name__)
+
+
+def _default_output_path(settings: QualitySettings, dataset_version: str | None) -> Path:
+    suffix = dataset_version or datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    return settings.resolved_artifacts_dir / f"quality_report_{suffix}.json"
+
+
+@app.command()
+def validate(
+    dataset_version: Optional[str] = typer.Option(
+        None,
+        "--dataset-version",
+        "-d",
+        help="Dataset version identifier to validate.",
+    ),
+    dry_run: bool = typer.Option(False, help="Run validation without writing report."),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Optional path for the JSON report. Defaults to the artifacts directory.",
+    ),
+) -> None:
+    """Validate a dataset and emit a structured report."""
+
+    configure_logging()
+    settings = get_settings()
+    LOGGER.debug("Loaded settings", extra={"settings": settings.model_dump()})
+
+    report: QualityReport = run_pipeline(settings, dataset_version)
+    status = report.status.value
+    typer.echo(status)
+
+    if dry_run:
+        LOGGER.info("Dry run requested; skipping report write")
+    else:
+        output_path = output or _default_output_path(settings, report.dataset_version)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as fp:
+            json.dump(report.to_dict(), fp, indent=2, ensure_ascii=False)
+        LOGGER.info("Report written", extra={"path": str(output_path)})
+
+    raise typer.Exit(code=0 if status != "FAIL" else 1)
+
+
+def main() -> None:
+    """Entrypoint for ``python -m agents.quality.app.cli``."""
+
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/quality/app/config.py
+++ b/agents/quality/app/config.py
@@ -1,0 +1,37 @@
+"""Configuration for the quality validation agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import DirectoryPath, Field, PostgresDsn
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class QualitySettings(BaseSettings):
+    """Runtime configuration driven by environment variables."""
+
+    database_url: Annotated[PostgresDsn, Field(alias="DATABASE_URL")]
+    database_schema: str = Field(default="public", alias="DATABASE_SCHEMA")
+    table_name: str = Field(default="normalized_flights", alias="TABLE_NAME")
+    artifacts_dir: DirectoryPath | Path = Field(
+        default_factory=lambda: Path("artifacts"), alias="ARTIFACTS_DIR"
+    )
+    default_dataset_version: str | None = Field(default=None, alias="DEFAULT_DATASET_VERSION")
+
+    model_config = SettingsConfigDict(env_prefix="QUALITY_", env_file=None, extra="ignore")
+
+    @property
+    def resolved_artifacts_dir(self) -> Path:
+        """Return a writable artifacts directory, creating it if necessary."""
+
+        path = Path(self.artifacts_dir)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+def get_settings() -> QualitySettings:
+    """Load :class:`QualitySettings` using the default environment lookup."""
+
+    return QualitySettings()  # type: ignore[arg-type]

--- a/agents/quality/app/logging.py
+++ b/agents/quality/app/logging.py
@@ -1,0 +1,22 @@
+"""Logging helpers for the quality validation agent."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+_DEFAULT_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def configure_logging(
+    level: str | int = logging.INFO, *, handlers: Iterable[logging.Handler] | None = None
+) -> None:
+    """Configure the root logger used by the CLI entrypoints."""
+
+    logging.basicConfig(level=level, format=_DEFAULT_FORMAT, handlers=list(handlers or []))
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-level logger."""
+
+    return logging.getLogger(name)

--- a/agents/quality/app/pipeline.py
+++ b/agents/quality/app/pipeline.py
@@ -1,0 +1,129 @@
+"""Co-ordinate data loading, validation checks and reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable
+
+import pandas as pd
+import psycopg
+
+from agents.ingest.app.schemas import CANONICAL_ORDER
+
+from .checks import CheckResult, CheckStatus, DataCheck, default_checks
+from .config import QualitySettings
+from .logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+DataLoader = Callable[[QualitySettings, str | None], pd.DataFrame]
+
+
+@dataclass(slots=True)
+class QualityReport:
+    """Serializable report describing the results of the validation run."""
+
+    dataset_version: str | None
+    generated_at: datetime
+    status: CheckStatus
+    checks: list[CheckResult]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON serialisable representation."""
+
+        return {
+            "dataset_version": self.dataset_version,
+            "generated_at": self.generated_at.isoformat(),
+            "status": self.status.value,
+            "checks": [
+                {
+                    "name": check.name,
+                    "status": check.status.value,
+                    "summary": check.summary,
+                    "details": check.details,
+                }
+                for check in self.checks
+            ],
+        }
+
+
+def load_flights(settings: QualitySettings, dataset_version: str | None) -> pd.DataFrame:
+    """Load normalized flights from Postgres using psycopg."""
+
+    query = [
+        "SELECT",
+        ", ".join(CANONICAL_ORDER),
+        f"FROM {settings.database_schema}.{settings.table_name}",
+    ]
+    params: list[Any] = []
+    if dataset_version:
+        query.append("WHERE dataset_version = %s")
+        params.append(dataset_version)
+
+    sql = " ".join(query)
+    LOGGER.info("Fetching flights from database", extra={"dataset_version": dataset_version})
+    with psycopg.connect(settings.database_url, autocommit=True) as conn:
+        frame = pd.read_sql(sql, conn, params=params or None)
+    LOGGER.info("Loaded %s records", len(frame))
+    return frame
+
+
+def run_checks(data: pd.DataFrame, checks: Iterable[DataCheck]) -> list[CheckResult]:
+    """Run the provided checks against ``data``."""
+
+    results: list[CheckResult] = []
+    for check in checks:
+        LOGGER.debug("Running check", extra={"check": check.name})
+        result = check.run(data)
+        results.append(result)
+        LOGGER.debug("Check result", extra={"check": check.name, "status": result.status.value})
+    return results
+
+
+def aggregate_status(results: Iterable[CheckResult]) -> CheckStatus:
+    """Aggregate individual check results into an overall status."""
+
+    final_status = CheckStatus.OK
+    for result in results:
+        if result.status is CheckStatus.FAIL:
+            return CheckStatus.FAIL
+        if result.status is CheckStatus.WARN and final_status is CheckStatus.OK:
+            final_status = CheckStatus.WARN
+    return final_status
+
+
+def run_pipeline(
+    settings: QualitySettings,
+    dataset_version: str | None = None,
+    *,
+    loader: DataLoader | None = None,
+    checks: Iterable[DataCheck] | None = None,
+) -> QualityReport:
+    """Execute the full validation flow."""
+
+    dataset = dataset_version or settings.default_dataset_version
+    data_loader = loader or load_flights
+    active_checks = list(checks or default_checks())
+
+    data = data_loader(settings, dataset)
+    results = run_checks(data, active_checks)
+    status = aggregate_status(results)
+
+    report = QualityReport(
+        dataset_version=dataset,
+        generated_at=datetime.now(timezone.utc),
+        status=status,
+        checks=results,
+    )
+    LOGGER.info("Validation complete", extra={"dataset_version": dataset, "status": status.value})
+    return report
+
+
+__all__ = [
+    "QualityReport",
+    "aggregate_status",
+    "load_flights",
+    "run_checks",
+    "run_pipeline",
+]

--- a/agents/quality/pyproject.toml
+++ b/agents/quality/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["hatchling>=1.21"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-quality"
+version = "0.1.0"
+description = "Quality validation agent for normalized flight datasets."
+readme = "README.md"
+authors = [{ name = "Twofold" }]
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+dependencies = [
+  "typer>=0.9",
+  "pydantic>=2.5",
+  "pydantic-settings>=2.2",
+  "pandas>=2.0",
+  "polars>=0.20",
+  "psycopg[binary]>=3.1",
+  "python-dateutil>=2.8",
+  "rich>=13.0",
+  "black>=23.0",
+  "ruff>=0.1",
+  "pytest>=7.0",
+]
+
+[project.optional-dependencies]
+checks = [
+  "great-expectations>=0.18",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "app",
+  "README.md",
+  "LICENSE",
+  "pyproject.toml",
+  "tests",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+

--- a/agents/quality/scripts/build.sh
+++ b/agents/quality/scripts/build.sh
@@ -1,41 +1,11 @@
-#!/usr/bin/env sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-: "${COMPONENT_NAME:=agent-quality}"
 : "${ARTIFACTS_DIR:=/artifacts}"
-: "${CACHE_DIR:=/cache}"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
-mkdir -p "${ARTIFACTS_DIR}" "${CACHE_DIR}"
+mkdir -p "${ARTIFACTS_DIR}"
+cd "${PROJECT_DIR}"
 
-case "$(basename "$0")" in
-  lint.sh)
-    echo "Running lint for ${COMPONENT_NAME} (skeleton)."
-    printf 'lint_ok=true\ncomponent=%s\n' "${COMPONENT_NAME}" \
-      > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_lint.log"
-    ;;
-  test.sh)
-    echo "Executing placeholder unit tests for ${COMPONENT_NAME}."
-    cat <<XML > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_tests.xml"
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="${COMPONENT_NAME}" tests="1" failures="0">
-  <testcase classname="placeholder" name="succeeds"/>
-</testsuite>
-XML
-    ;;
-  build.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_build.txt"
-    echo "Building ${COMPONENT_NAME} (placeholder)." | tee "${artifact}"
-    printf 'artifact=%s\n' "${artifact}" >> "${artifact}"
-    ;;
-  publish.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_publish.log"
-    {
-      echo "Publishing ${COMPONENT_NAME} (placeholder)."
-      echo "timestamp=$(date -u +%FT%TZ)"
-    } > "${artifact}"
-    ;;
-  *)
-    echo "Unknown script $(basename "$0")" >&2
-    exit 1
-    ;;
-esac
+python -m build --wheel --outdir "${ARTIFACTS_DIR}"

--- a/agents/quality/scripts/lint.sh
+++ b/agents/quality/scripts/lint.sh
@@ -1,41 +1,13 @@
-#!/usr/bin/env sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-: "${COMPONENT_NAME:=agent-quality}"
 : "${ARTIFACTS_DIR:=/artifacts}"
-: "${CACHE_DIR:=/cache}"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
-mkdir -p "${ARTIFACTS_DIR}" "${CACHE_DIR}"
+mkdir -p "${ARTIFACTS_DIR}"
+cd "${PROJECT_DIR}"
+export PYTHONPATH="$(pwd)/../..:${PYTHONPATH:-}"
 
-case "$(basename "$0")" in
-  lint.sh)
-    echo "Running lint for ${COMPONENT_NAME} (skeleton)."
-    printf 'lint_ok=true\ncomponent=%s\n' "${COMPONENT_NAME}" \
-      > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_lint.log"
-    ;;
-  test.sh)
-    echo "Executing placeholder unit tests for ${COMPONENT_NAME}."
-    cat <<XML > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_tests.xml"
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="${COMPONENT_NAME}" tests="1" failures="0">
-  <testcase classname="placeholder" name="succeeds"/>
-</testsuite>
-XML
-    ;;
-  build.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_build.txt"
-    echo "Building ${COMPONENT_NAME} (placeholder)." | tee "${artifact}"
-    printf 'artifact=%s\n' "${artifact}" >> "${artifact}"
-    ;;
-  publish.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_publish.log"
-    {
-      echo "Publishing ${COMPONENT_NAME} (placeholder)."
-      echo "timestamp=$(date -u +%FT%TZ)"
-    } > "${artifact}"
-    ;;
-  *)
-    echo "Unknown script $(basename "$0")" >&2
-    exit 1
-    ;;
-esac
+python -m ruff check app tests > "${ARTIFACTS_DIR}/ruff.log"
+python -m black --check app tests > "${ARTIFACTS_DIR}/black.log"

--- a/agents/quality/scripts/publish.sh
+++ b/agents/quality/scripts/publish.sh
@@ -1,41 +1,11 @@
-#!/usr/bin/env sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-: "${COMPONENT_NAME:=agent-quality}"
 : "${ARTIFACTS_DIR:=/artifacts}"
-: "${CACHE_DIR:=/cache}"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
-mkdir -p "${ARTIFACTS_DIR}" "${CACHE_DIR}"
+mkdir -p "${ARTIFACTS_DIR}"
+cd "${PROJECT_DIR}"
 
-case "$(basename "$0")" in
-  lint.sh)
-    echo "Running lint for ${COMPONENT_NAME} (skeleton)."
-    printf 'lint_ok=true\ncomponent=%s\n' "${COMPONENT_NAME}" \
-      > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_lint.log"
-    ;;
-  test.sh)
-    echo "Executing placeholder unit tests for ${COMPONENT_NAME}."
-    cat <<XML > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_tests.xml"
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="${COMPONENT_NAME}" tests="1" failures="0">
-  <testcase classname="placeholder" name="succeeds"/>
-</testsuite>
-XML
-    ;;
-  build.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_build.txt"
-    echo "Building ${COMPONENT_NAME} (placeholder)." | tee "${artifact}"
-    printf 'artifact=%s\n' "${artifact}" >> "${artifact}"
-    ;;
-  publish.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_publish.log"
-    {
-      echo "Publishing ${COMPONENT_NAME} (placeholder)."
-      echo "timestamp=$(date -u +%FT%TZ)"
-    } > "${artifact}"
-    ;;
-  *)
-    echo "Unknown script $(basename "$0")" >&2
-    exit 1
-    ;;
-esac
+python -m build --sdist --wheel --outdir "${ARTIFACTS_DIR}"

--- a/agents/quality/scripts/test.sh
+++ b/agents/quality/scripts/test.sh
@@ -1,41 +1,12 @@
-#!/usr/bin/env sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-: "${COMPONENT_NAME:=agent-quality}"
 : "${ARTIFACTS_DIR:=/artifacts}"
-: "${CACHE_DIR:=/cache}"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
-mkdir -p "${ARTIFACTS_DIR}" "${CACHE_DIR}"
+mkdir -p "${ARTIFACTS_DIR}"
+cd "${PROJECT_DIR}"
+export PYTHONPATH="$(pwd)/../..:${PYTHONPATH:-}"
 
-case "$(basename "$0")" in
-  lint.sh)
-    echo "Running lint for ${COMPONENT_NAME} (skeleton)."
-    printf 'lint_ok=true\ncomponent=%s\n' "${COMPONENT_NAME}" \
-      > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_lint.log"
-    ;;
-  test.sh)
-    echo "Executing placeholder unit tests for ${COMPONENT_NAME}."
-    cat <<XML > "${ARTIFACTS_DIR}/${COMPONENT_NAME}_tests.xml"
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="${COMPONENT_NAME}" tests="1" failures="0">
-  <testcase classname="placeholder" name="succeeds"/>
-</testsuite>
-XML
-    ;;
-  build.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_build.txt"
-    echo "Building ${COMPONENT_NAME} (placeholder)." | tee "${artifact}"
-    printf 'artifact=%s\n' "${artifact}" >> "${artifact}"
-    ;;
-  publish.sh)
-    artifact="${ARTIFACTS_DIR}/${COMPONENT_NAME}_publish.log"
-    {
-      echo "Publishing ${COMPONENT_NAME} (placeholder)."
-      echo "timestamp=$(date -u +%FT%TZ)"
-    } > "${artifact}"
-    ;;
-  *)
-    echo "Unknown script $(basename "$0")" >&2
-    exit 1
-    ;;
-esac
+python -m pytest --junitxml "${ARTIFACTS_DIR}/pytest.xml"

--- a/agents/quality/tests/test_pipeline.py
+++ b/agents/quality/tests/test_pipeline.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from agents.ingest.app.schemas import CANONICAL_ORDER
+from agents.quality.app.checks import CheckStatus
+from agents.quality.app.config import QualitySettings
+from agents.quality.app.pipeline import QualityReport, run_pipeline
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SAMPLE_PATH = REPO_ROOT / "samples/rosaviation_sample.csv"
+
+
+def _sample_dataframe() -> pd.DataFrame:
+    raw = pd.read_csv(SAMPLE_PATH)
+    raw["start_time_utc"] = pd.to_datetime(raw.pop("start_time"), utc=True)
+    raw["end_time_utc"] = pd.to_datetime(raw.pop("end_time"), utc=True)
+    raw["duration_minutes"] = raw["duration_minutes"].astype(float)
+    raw["surrogate_id"] = None
+    raw["superseded"] = False
+
+    for column in CANONICAL_ORDER:
+        if column not in raw.columns:
+            if column == "superseded":
+                raw[column] = False
+            else:
+                raw[column] = None
+
+    return raw[CANONICAL_ORDER].copy()
+
+
+def _make_settings(tmp_path: Path) -> QualitySettings:
+    return QualitySettings.model_validate(
+        {
+            "DATABASE_URL": "postgresql://user:pass@localhost:5432/testdb",
+            "DATABASE_SCHEMA": "public",
+            "TABLE_NAME": "normalized_flights",
+            "ARTIFACTS_DIR": str(tmp_path),
+        }
+    )
+
+
+def test_run_pipeline_success(tmp_path: Path) -> None:
+    settings = _make_settings(tmp_path)
+    dataframe = _sample_dataframe()
+
+    def loader(_: QualitySettings, __: str | None) -> pd.DataFrame:
+        return dataframe
+
+    report: QualityReport = run_pipeline(settings, dataset_version="2024-01", loader=loader)
+
+    assert report.status is CheckStatus.OK
+    assert {check.status for check in report.checks} == {CheckStatus.OK}
+
+
+def test_run_pipeline_detects_failures(tmp_path: Path) -> None:
+    settings = _make_settings(tmp_path)
+    dataframe = _sample_dataframe()
+    dataframe.loc[0, "duration_minutes"] = -5
+    dataframe.loc[1, "latitude"] = 120
+    dataframe = pd.concat([dataframe, dataframe.iloc[[0]]], ignore_index=True)
+
+    def loader(_: QualitySettings, __: str | None) -> pd.DataFrame:
+        return dataframe
+
+    report = run_pipeline(settings, dataset_version="2024-02", loader=loader)
+
+    statuses = {check.name: check.status for check in report.checks}
+    assert statuses["duration_range"] is CheckStatus.FAIL
+    assert statuses["coordinate_range"] is CheckStatus.FAIL
+    assert statuses["uniqueness"] is CheckStatus.FAIL
+    assert report.status is CheckStatus.FAIL
+
+
+def test_monthly_completeness_warns_for_gaps(tmp_path: Path) -> None:
+    settings = _make_settings(tmp_path)
+    dataframe = _sample_dataframe().iloc[:2].copy()
+    dataframe.loc[:, "start_time_utc"] = pd.to_datetime(
+        [
+            "2024-01-01T00:00:00Z",
+            "2024-03-01T00:00:00Z",
+        ]
+    )
+    dataframe.loc[:, "end_time_utc"] = pd.to_datetime(
+        [
+            "2024-01-01T01:00:00Z",
+            "2024-03-01T01:00:00Z",
+        ]
+    )
+
+    def loader(_: QualitySettings, __: str | None) -> pd.DataFrame:
+        return dataframe
+
+    report = run_pipeline(settings, dataset_version="2024-gap", loader=loader)
+
+    statuses = {check.name: check.status for check in report.checks}
+    assert statuses["monthly_completeness"] is CheckStatus.WARN
+    assert report.status is CheckStatus.WARN


### PR DESCRIPTION
## Summary
- add a dedicated pyproject and package scaffolding for the quality agent including settings, logging, CLI, and reporting pipeline
- implement schema, range, uniqueness, completeness, and outlier checks with JSON-ready summaries
- replace quality scripts with real lint/test/build commands and document setup and usage in the README

## Testing
- python -m pytest agents/quality/tests
- python -m ruff check agents/quality/app agents/quality/tests

------
https://chatgpt.com/codex/tasks/task_e_68de51a09754832d89d68122b6b088ba