### PR TITLE
Add persistence for quality reports and extend CLI options

### DIFF
--- a/agents/quality/app/cli.py
+++ b/agents/quality/app/cli.py
@@ -8,10 +8,13 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+from psycopg.conninfo import make_conninfo
 
+from .checks import CheckStatus
 from .config import QualitySettings, get_settings
 from .logging import configure_logging, get_logger
 from .pipeline import QualityReport, run_pipeline
+from .repository import QualityRepository
 
 app = typer.Typer(help="Quality validation utilities for normalized flights.")
 LOGGER = get_logger(__name__)
@@ -22,6 +25,40 @@ def _default_output_path(settings: QualitySettings, dataset_version: str | None)
     return settings.resolved_artifacts_dir / f"quality_report_{suffix}.json"
 
 
+def _violations_output_path(report_path: Path) -> Path:
+    return report_path.with_name(report_path.stem.replace("report", "violations") + ".json")
+
+
+def _override_settings(
+    settings: QualitySettings,
+    *,
+    database_url: Optional[str] = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    dbname: Optional[str] = None,
+    user: Optional[str] = None,
+    password: Optional[str] = None,
+    sslmode: Optional[str] = None,
+) -> QualitySettings:
+    """Return a copy of settings with database URL overrides applied."""
+
+    base_url = database_url or str(settings.database_url)
+    overrides = {
+        "host": host,
+        "port": port,
+        "dbname": dbname,
+        "user": user,
+        "password": password,
+        "sslmode": sslmode,
+    }
+    filtered = {key: value for key, value in overrides.items() if value is not None}
+    if filtered:
+        base_url = make_conninfo(base_url, **filtered)
+    if database_url or filtered:
+        return settings.model_copy(update={"database_url": base_url})
+    return settings
+
+
 @app.command()
 def validate(
     dataset_version: Optional[str] = typer.Option(
@@ -30,34 +67,72 @@ def validate(
         "-d",
         help="Dataset version identifier to validate.",
     ),
-    dry_run: bool = typer.Option(False, help="Run validation without writing report."),
+    dry_run: bool = typer.Option(
+        False, help="Run validation without writing to the database. Artifacts are still saved."
+    ),
     output: Optional[Path] = typer.Option(
         None,
         "--output",
         "-o",
         help="Optional path for the JSON report. Defaults to the artifacts directory.",
     ),
+    database_url: Optional[str] = typer.Option(None, help="Override Postgres DSN."),
+    db_host: Optional[str] = typer.Option(None, help="Postgres hostname override."),
+    db_port: Optional[int] = typer.Option(None, help="Postgres port override."),
+    db_name: Optional[str] = typer.Option(None, help="Postgres database name override."),
+    db_user: Optional[str] = typer.Option(None, help="Postgres user override."),
+    db_password: Optional[str] = typer.Option(None, help="Postgres password override."),
+    db_sslmode: Optional[str] = typer.Option(None, help="Postgres sslmode override."),
 ) -> None:
     """Validate a dataset and emit a structured report."""
 
     configure_logging()
     settings = get_settings()
+    settings = _override_settings(
+        settings,
+        database_url=database_url,
+        host=db_host,
+        port=db_port,
+        dbname=db_name,
+        user=db_user,
+        password=db_password,
+        sslmode=db_sslmode,
+    )
     LOGGER.debug("Loaded settings", extra={"settings": settings.model_dump()})
 
-    report: QualityReport = run_pipeline(settings, dataset_version)
-    status = report.status.value
-    typer.echo(status)
+    repository = QualityRepository(str(settings.database_url))
+    report: QualityReport = run_pipeline(
+        settings,
+        dataset_version,
+        repository=repository,
+        dry_run=dry_run,
+    )
+    typer.echo(report.quality_status)
 
-    if dry_run:
-        LOGGER.info("Dry run requested; skipping report write")
-    else:
-        output_path = output or _default_output_path(settings, report.dataset_version)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        with output_path.open("w", encoding="utf-8") as fp:
-            json.dump(report.to_dict(), fp, indent=2, ensure_ascii=False)
-        LOGGER.info("Report written", extra={"path": str(output_path)})
+    output_path = output or _default_output_path(settings, report.dataset_version)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fp:
+        json.dump(report.to_dict(), fp, indent=2, ensure_ascii=False)
+    violations_path = _violations_output_path(output_path)
+    with violations_path.open("w", encoding="utf-8") as fp:
+        json.dump(
+            {
+                "warn_count": report.warn_count,
+                "fail_count": report.fail_count,
+                "total": report.violation_count,
+                "quality_status": report.quality_status,
+            },
+            fp,
+            indent=2,
+            ensure_ascii=False,
+        )
+    LOGGER.info(
+        "Artifacts written",
+        extra={"report_path": str(output_path), "violations_path": str(violations_path)},
+    )
 
-    raise typer.Exit(code=0 if status != "FAIL" else 1)
+    exit_code = 0 if report.status is not CheckStatus.FAIL else 1
+    raise typer.Exit(code=exit_code)
 
 
 def main() -> None:

--- a/agents/quality/app/pipeline.py
+++ b/agents/quality/app/pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Iterator
 
 import pandas as pd
 import psycopg
@@ -14,10 +14,18 @@ from agents.ingest.app.schemas import CANONICAL_ORDER
 from .checks import CheckResult, CheckStatus, DataCheck, default_checks
 from .config import QualitySettings
 from .logging import get_logger
+from .repository import QualityReportEntry, QualityRepository
 
 LOGGER = get_logger(__name__)
 
 DataLoader = Callable[[QualitySettings, str | None], pd.DataFrame]
+
+
+QUALITY_STATUS_MAP: dict[CheckStatus, str] = {
+    CheckStatus.OK: "validated",
+    CheckStatus.WARN: "quality_warn",
+    CheckStatus.FAIL: "quality_fail",
+}
 
 
 @dataclass(slots=True)
@@ -27,7 +35,11 @@ class QualityReport:
     dataset_version: str | None
     generated_at: datetime
     status: CheckStatus
+    quality_status: str
     checks: list[CheckResult]
+    entries: list[QualityReportEntry]
+    warn_count: int
+    fail_count: int
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON serialisable representation."""
@@ -36,6 +48,9 @@ class QualityReport:
             "dataset_version": self.dataset_version,
             "generated_at": self.generated_at.isoformat(),
             "status": self.status.value,
+            "quality_status": self.quality_status,
+            "warn_count": self.warn_count,
+            "fail_count": self.fail_count,
             "checks": [
                 {
                     "name": check.name,
@@ -45,7 +60,21 @@ class QualityReport:
                 }
                 for check in self.checks
             ],
+            "entries": [
+                {
+                    "check_name": entry.check_name,
+                    "severity": entry.severity.value,
+                    "details": entry.payload,
+                }
+                for entry in self.entries
+            ],
         }
+
+    @property
+    def violation_count(self) -> int:
+        """Return the total number of WARN/FAIL checks."""
+
+        return self.warn_count + self.fail_count
 
 
 def load_flights(settings: QualitySettings, dataset_version: str | None) -> pd.DataFrame:
@@ -93,12 +122,59 @@ def aggregate_status(results: Iterable[CheckResult]) -> CheckStatus:
     return final_status
 
 
+def _iter_sample_rows(details: dict[str, Any] | None) -> Iterator[dict[str, Any]]:
+    """Yield dict rows stored inside the ``details`` payload (if any)."""
+
+    if not details:
+        return
+    for key in ("sample_rows", "rows", "violations"):
+        value = details.get(key)
+        if isinstance(value, list):
+            for row in value:
+                if isinstance(row, dict):
+                    yield row
+
+
+def summarise_results(results: Iterable[CheckResult]) -> list[QualityReportEntry]:
+    """Convert raw :class:`CheckResult` objects into persistence payloads."""
+
+    entries: list[QualityReportEntry] = []
+    for result in results:
+        details = result.details or {}
+        payload: dict[str, Any] = {"summary": result.summary}
+        if details:
+            payload["details"] = details
+
+        rows = list(_iter_sample_rows(details))
+        impacted_regions = sorted(
+            {str(row["region_code"]) for row in rows if row.get("region_code")}
+        )
+        impacted_records = sorted(
+            {str(row["flight_id"]) for row in rows if row.get("flight_id")}
+        )
+        if impacted_regions:
+            payload["impacted_regions"] = impacted_regions
+        if impacted_records:
+            payload["impacted_records"] = impacted_records
+
+        entries.append(
+            QualityReportEntry(
+                check_name=result.name,
+                severity=result.status,
+                payload=payload,
+            )
+        )
+    return entries
+
+
 def run_pipeline(
     settings: QualitySettings,
     dataset_version: str | None = None,
     *,
     loader: DataLoader | None = None,
     checks: Iterable[DataCheck] | None = None,
+    repository: QualityRepository | None = None,
+    dry_run: bool = False,
 ) -> QualityReport:
     """Execute the full validation flow."""
 
@@ -109,20 +185,58 @@ def run_pipeline(
     data = data_loader(settings, dataset)
     results = run_checks(data, active_checks)
     status = aggregate_status(results)
+    entries = summarise_results(results)
+    warn_count = sum(1 for entry in entries if entry.severity is CheckStatus.WARN)
+    fail_count = sum(1 for entry in entries if entry.severity is CheckStatus.FAIL)
+    quality_status = QUALITY_STATUS_MAP[status]
 
     report = QualityReport(
         dataset_version=dataset,
         generated_at=datetime.now(timezone.utc),
         status=status,
+        quality_status=quality_status,
         checks=results,
+        entries=entries,
+        warn_count=warn_count,
+        fail_count=fail_count,
     )
     LOGGER.info("Validation complete", extra={"dataset_version": dataset, "status": status.value})
+
+    if repository and not dry_run and dataset:
+        LOGGER.info(
+            "Persisting quality results",
+            extra={
+                "dataset_version": dataset,
+                "warn_count": warn_count,
+                "fail_count": fail_count,
+                "quality_status": quality_status,
+            },
+        )
+        with repository.connection() as conn:
+            dataset_id = repository.fetch_dataset_version_id(conn, dataset)
+            repository.replace_quality_reports(conn, dataset_id, entries)
+            repository.update_dataset_version(
+                conn,
+                dataset_id,
+                status=quality_status,
+                warn_count=warn_count,
+                fail_count=fail_count,
+            )
+    elif repository and not dataset:
+        LOGGER.warning(
+            "Dataset version missing; skipping persistence",
+            extra={"dry_run": dry_run},
+        )
+    elif dry_run:
+        LOGGER.info("Dry run enabled; database writes skipped")
+
     return report
 
 
 __all__ = [
     "QualityReport",
     "aggregate_status",
+    "summarise_results",
     "load_flights",
     "run_checks",
     "run_pipeline",

--- a/agents/quality/app/repository.py
+++ b/agents/quality/app/repository.py
@@ -1,0 +1,147 @@
+"""Database persistence helpers for the quality validation pipeline."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterable, Iterator
+
+from psycopg import Connection, connect
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from .checks import CheckStatus
+
+
+@dataclass(slots=True)
+class QualityReportEntry:
+    """Normalized payload describing a single quality check outcome."""
+
+    check_name: str
+    severity: CheckStatus
+    payload: dict[str, Any]
+    region_id: int | None = None
+
+
+@dataclass(slots=True)
+class QualityRepository:
+    """Provide high-level helpers for persisting quality results."""
+
+    database_url: str
+
+    @contextmanager
+    def connection(self) -> Iterator[Connection]:
+        """Yield a transactional psycopg connection."""
+
+        conn = connect(self.database_url)
+        try:
+            yield conn
+            conn.commit()
+        except Exception:  # pragma: no cover - defensive rollback
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def fetch_dataset_version_id(self, conn: Connection, version_name: str) -> int:
+        """Return the primary key for ``dataset_version`` matching ``version_name``."""
+
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT id
+                  FROM dataset_version
+                 WHERE version_name = %s
+                """,
+                (version_name,),
+            )
+            row = cur.fetchone()
+            if not row:
+                msg = f"dataset_version '{version_name}' not found"
+                raise ValueError(msg)
+            return int(row["id"])
+
+    def replace_quality_reports(
+        self,
+        conn: Connection,
+        dataset_version_id: int,
+        entries: Iterable[QualityReportEntry],
+    ) -> None:
+        """Replace existing rows in ``quality_report`` for the dataset version."""
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                DELETE FROM quality_report
+                 WHERE dataset_version_id = %s
+                """,
+                (dataset_version_id,),
+            )
+            for entry in entries:
+                cur.execute(
+                    """
+                    INSERT INTO quality_report (
+                        dataset_version_id,
+                        region_id,
+                        check_name,
+                        severity,
+                        details
+                    )
+                    VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (
+                        dataset_version_id,
+                        entry.region_id,
+                        entry.check_name,
+                        entry.severity.value,
+                        Jsonb(entry.payload),
+                    ),
+                )
+
+    def _ensure_quality_columns(self, conn: Connection) -> None:
+        """Ensure auxiliary quality-related columns exist (idempotent)."""
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                ALTER TABLE dataset_version
+                ADD COLUMN IF NOT EXISTS quality_warn_count INTEGER NOT NULL DEFAULT 0
+                """
+            )
+            cur.execute(
+                """
+                ALTER TABLE dataset_version
+                ADD COLUMN IF NOT EXISTS quality_fail_count INTEGER NOT NULL DEFAULT 0
+                """
+            )
+
+    def update_dataset_version(
+        self,
+        conn: Connection,
+        dataset_version_id: int,
+        *,
+        status: str,
+        warn_count: int,
+        fail_count: int,
+    ) -> None:
+        """Persist aggregate status flags back to ``dataset_version``."""
+
+        self._ensure_quality_columns(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE dataset_version
+                   SET status = %s,
+                       validated_at = NOW(),
+                       quality_warn_count = %s,
+                       quality_fail_count = %s
+                 WHERE id = %s
+                """,
+                (status, warn_count, fail_count, dataset_version_id),
+            )
+
+
+__all__ = [
+    "QualityReportEntry",
+    "QualityRepository",
+]

--- a/agents/quality/tests/test_repository.py
+++ b/agents/quality/tests/test_repository.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+import sys
+
+import pytest
+from psycopg.types.json import Jsonb
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from agents.quality.app.checks import CheckStatus
+from agents.quality.app.repository import QualityReportEntry, QualityRepository
+
+
+def _make_connection() -> tuple[MagicMock, MagicMock]:
+    connection = MagicMock()
+    cursor = MagicMock()
+    connection.cursor.return_value.__enter__.return_value = cursor
+    return connection, cursor
+
+
+def test_fetch_dataset_version_id_returns_value() -> None:
+    repo = QualityRepository("postgresql://user:pass@localhost:5432/testdb")
+    connection, cursor = _make_connection()
+    cursor.fetchone.return_value = {"id": 42}
+
+    version_id = repo.fetch_dataset_version_id(connection, "2024-Q1")
+
+    assert version_id == 42
+    cursor.execute.assert_called_once()
+    sql, params = cursor.execute.call_args[0]
+    assert "FROM dataset_version" in sql
+    assert params == ("2024-Q1",)
+
+
+def test_fetch_dataset_version_id_missing_raises() -> None:
+    repo = QualityRepository("postgresql://user:pass@localhost:5432/testdb")
+    connection, cursor = _make_connection()
+    cursor.fetchone.return_value = None
+
+    with pytest.raises(ValueError):
+        repo.fetch_dataset_version_id(connection, "missing")
+
+
+def test_replace_quality_reports_inserts_entries() -> None:
+    repo = QualityRepository("postgresql://user:pass@localhost:5432/testdb")
+    connection, cursor = _make_connection()
+    entry = QualityReportEntry(
+        check_name="duration_range",
+        severity=CheckStatus.FAIL,
+        payload={"summary": "out of range", "impacted_records": ["A1"]},
+    )
+
+    repo.replace_quality_reports(connection, 5, [entry])
+
+    assert cursor.execute.call_count == 2
+    delete_call = cursor.execute.call_args_list[0]
+    insert_call = cursor.execute.call_args_list[1]
+    delete_sql, delete_params = delete_call[0]
+    assert "DELETE FROM quality_report" in delete_sql
+    assert delete_params == (5,)
+    insert_sql, insert_params = insert_call[0]
+    assert "INSERT INTO quality_report" in insert_sql
+    assert insert_params[0] == 5
+    assert insert_params[2] == "duration_range"
+    assert insert_params[3] == "FAIL"
+    assert isinstance(insert_params[4], Jsonb)
+
+
+def test_update_dataset_version_sets_status() -> None:
+    repo = QualityRepository("postgresql://user:pass@localhost:5432/testdb")
+    connection, cursor = _make_connection()
+
+    repo.update_dataset_version(connection, 8, status="quality_warn", warn_count=2, fail_count=1)
+
+    # First two calls come from ensuring helper columns, final call performs UPDATE
+    sql_statements = [call[0][0] for call in cursor.execute.call_args_list]
+    assert any("ALTER TABLE dataset_version" in sql for sql in sql_statements[:2])
+    assert any("UPDATE dataset_version" in sql for sql in sql_statements)
+    _, update_params = cursor.execute.call_args_list[-1][0]
+    assert update_params == ("quality_warn", 2, 1, 8)


### PR DESCRIPTION
## Summary
- introduce a dedicated quality repository to persist check results and dataset version status updates
- aggregate check outcomes in the pipeline, emit warn/fail counters, and support dry-run persistence control
- extend the CLI with Postgres connection overrides, artifact outputs for dry runs, and update the README alongside new tests

## Testing
- pytest agents/quality/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68de57ed6a34832d89e4a482fb703fb7