### PR TITLE
Add flight quality issue tracking and persistence

### DIFF
--- a/infra/postgres/migrations/0002_quality_flags.sql
+++ b/infra/postgres/migrations/0002_quality_flags.sql
@@ -1,0 +1,19 @@
+-- 0002_quality_flags.sql
+-- Track quality issues for specific flights
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS flight_quality_issues (
+    id                  BIGSERIAL PRIMARY KEY,
+    dataset_version_id  BIGINT      NOT NULL REFERENCES dataset_version(id) ON DELETE CASCADE,
+    flight_uid          TEXT        NOT NULL,
+    check_name          TEXT        NOT NULL,
+    severity            TEXT        NOT NULL,
+    details             JSONB,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_flight_quality_issues_search
+    ON flight_quality_issues (dataset_version_id, flight_uid);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a migration that introduces the flight_quality_issues table for WARN/FAIL tracking
- extend the quality repository with helpers for flight-level issues and persist them from the pipeline
- expose flight issue details in reports, document the lookup workflow, and cover the behaviour with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de5f329ab8832d9a96e16911608e17